### PR TITLE
Limit maximum password length to <=72 char length

### DIFF
--- a/src/main/java/ru/mystamps/web/model/ActivateAccountForm.java
+++ b/src/main/java/ru/mystamps/web/model/ActivateAccountForm.java
@@ -97,11 +97,18 @@ public class ActivateAccountForm implements ActivateAccountDto {
 	private String name;
 	
 	@NotEmpty(groups = Password1Checks.class)
-	@Size(
-		min = ValidationRules.PASSWORD_MIN_LENGTH,
-		message = "{value.too-short}",
-		groups = Password2Checks.class
-	)
+	@Size.List({
+		@Size(
+			min = ValidationRules.PASSWORD_MIN_LENGTH,
+			message = "{value.too-short}",
+			groups = Password2Checks.class
+		),
+		@Size(
+			max = ValidationRules.PASSWORD_MAX_LENGTH,
+			message = "{value.too-long}",
+			groups = Password2Checks.class
+		)
+	})
 	private String password;
 	
 	@NotEmpty(groups = PasswordConfirmation1Checks.class)

--- a/src/main/java/ru/mystamps/web/validation/ValidationRules.java
+++ b/src/main/java/ru/mystamps/web/validation/ValidationRules.java
@@ -32,6 +32,9 @@ public final class ValidationRules {
 	public static final String NAME_NO_HYPHEN_REGEXP = "[ \\p{L}]([- \\p{L}]+[ \\p{L}])*";
 	
 	public static final int PASSWORD_MIN_LENGTH = 4;
+	// We limit max length because bcrypt has a maximum password length.
+	// See also: http://www.mscharhag.com/software-development/bcrypt-maximum-password-length
+	public static final int PASSWORD_MAX_LENGTH = 72;
 	
 	public static final int EMAIL_MAX_LENGTH = Db.UsersActivation.EMAIL_LENGTH;
 	


### PR DESCRIPTION
Addressed to #453

Added new constant max password fields to ValidationRules and added maximum password  length annotation. 