### PR TITLE
Add ability to specify URL for an image

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -15,6 +15,7 @@
 - (functionality)  name of category/country in Russian now are optional fields
 - (functionality)  preview now is generated after uploading an image
 - (functionality)  add interface for adding buyers and sellers
+- (functionality)  add capability to specify image URL (as alternative to providing a file)
 
 0.3
 - (functionality)  implemented possibility to user to add series to his collection

--- a/src/main/config/findbugs-filter.xml
+++ b/src/main/config/findbugs-filter.xml
@@ -10,6 +10,15 @@
 	</Match>
 	<Match>
 		<!--
+			String[] allowedContentTypes: potentially caller can modify data after passing it to the
+			constructor. I don't want to fix it because all such places are known and under our
+			control.
+		-->
+		<Class name="ru.mystamps.web.service.HttpURLConnectionDownloaderService" />
+		<Bug pattern="EI_EXPOSE_REP2" />
+	</Match>
+	<Match>
+		<!--
 			It's ok, that we're don't override parent's equals() method.
 		-->
 		<Class name="ru.mystamps.web.support.spring.security.CustomUserDetails" />

--- a/src/main/java/ru/mystamps/web/config/ControllersConfig.java
+++ b/src/main/java/ru/mystamps/web/config/ControllersConfig.java
@@ -20,6 +20,7 @@ package ru.mystamps.web.config;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import lombok.RequiredArgsConstructor;
 
@@ -131,4 +132,10 @@ public class ControllersConfig {
 		);
 	}
 
+	@Bean
+	@Profile({ "test", "travis" })
+	public TestController getTestController() {
+		return new TestController();
+	}
+	
 }

--- a/src/main/java/ru/mystamps/web/config/MvcConfig.java
+++ b/src/main/java/ru/mystamps/web/config/MvcConfig.java
@@ -47,6 +47,7 @@ import lombok.RequiredArgsConstructor;
 
 import ru.mystamps.web.Url;
 import ru.mystamps.web.controller.converter.LinkEntityDtoGenericConverter;
+import ru.mystamps.web.controller.interceptor.DownloadImageInterceptor;
 import ru.mystamps.web.support.spring.security.CurrentUserArgumentResolver;
 
 @Configuration
@@ -126,6 +127,10 @@ public class MvcConfig extends WebMvcConfigurerAdapter {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(getLocaleChangeInterceptor());
+		
+		registry
+			.addInterceptor(getDownloadImageInterceptor())
+			.addPathPatterns(Url.ADD_SERIES_PAGE);
 	}
 	
 	@Override
@@ -147,6 +152,10 @@ public class MvcConfig extends WebMvcConfigurerAdapter {
 		LocaleChangeInterceptor interceptor = new LocaleChangeInterceptor();
 		interceptor.setParamName("lang");
 		return interceptor;
+	}
+	
+	private HandlerInterceptor getDownloadImageInterceptor() {
+		return new DownloadImageInterceptor(servicesConfig.getDownloaderService());
 	}
 	
 }

--- a/src/main/java/ru/mystamps/web/config/MvcConfig.java
+++ b/src/main/java/ru/mystamps/web/config/MvcConfig.java
@@ -130,7 +130,7 @@ public class MvcConfig extends WebMvcConfigurerAdapter {
 		
 		registry
 			.addInterceptor(getDownloadImageInterceptor())
-			.addPathPatterns(Url.ADD_SERIES_PAGE);
+			.addPathPatterns(Url.ADD_SERIES_PAGE, Url.ADD_IMAGE_SERIES_PAGE);
 	}
 	
 	@Override

--- a/src/main/java/ru/mystamps/web/config/ServicesConfig.java
+++ b/src/main/java/ru/mystamps/web/config/ServicesConfig.java
@@ -90,6 +90,11 @@ public class ServicesConfig {
 	}
 	
 	@Bean
+	public DownloaderService getDownloaderService() {
+		return new HttpURLConnectionDownloaderService(new String[]{"image/jpeg", "image/png"});
+	}
+	
+	@Bean
 	public ImageService getImageService() {
 		return new ImageServiceImpl(
 			LoggerFactory.getLogger(ImageServiceImpl.class),

--- a/src/main/java/ru/mystamps/web/controller/SeriesController.java
+++ b/src/main/java/ru/mystamps/web/controller/SeriesController.java
@@ -63,6 +63,7 @@ import ru.mystamps.web.controller.converter.annotation.CurrentUser;
 import ru.mystamps.web.controller.dto.AddImageForm;
 import ru.mystamps.web.controller.dto.AddSeriesForm;
 import ru.mystamps.web.controller.dto.AddSeriesSalesForm;
+import ru.mystamps.web.controller.dto.NullableImageUrl;
 import ru.mystamps.web.controller.interceptor.DownloadImageInterceptor;
 import ru.mystamps.web.dao.dto.EntityWithIdDto;
 import ru.mystamps.web.dao.dto.LinkEntityDto;
@@ -499,7 +500,7 @@ public class SeriesController {
 	}
 	
 	private static void loadErrorsFromDownloadInterceptor(
-		AddSeriesForm form,
+		NullableImageUrl form,
 		BindingResult result,
 		HttpServletRequest request) {
 		
@@ -525,7 +526,7 @@ public class SeriesController {
 						"image",
 						"ru.mystamps.web.support.beanvalidation.NotEmptyFilename.message"
 					);
-					form.setImageUrl(null);
+					form.nullifyImageUrl();
 					break;
 				default:
 					result.rejectValue(

--- a/src/main/java/ru/mystamps/web/controller/SeriesController.java
+++ b/src/main/java/ru/mystamps/web/controller/SeriesController.java
@@ -266,14 +266,47 @@ public class SeriesController {
 		return "series/info";
 	}
 	
-	@PostMapping(Url.ADD_IMAGE_SERIES_PAGE)
-	public String processImage(
-		@Valid AddImageForm form,
+	@SuppressWarnings("checkstyle:parameternumber")
+	@PostMapping(path = Url.ADD_IMAGE_SERIES_PAGE, params = "imageUrl")
+	public String processImageWithImageUrl(
+		@Validated({
+			AddImageForm.ImageUrlChecks.class,
+			AddImageForm.ImageChecks.class
+		}) AddImageForm form,
 		BindingResult result,
 		@PathVariable("id") Integer seriesId,
 		Model model,
 		@CurrentUser Integer currentUserId,
 		Locale userLocale,
+		HttpServletRequest request,
+		HttpServletResponse response)
+		throws IOException {
+		
+		return processImage(
+			form,
+			result,
+			seriesId,
+			model,
+			currentUserId,
+			userLocale,
+			request,
+			response
+		);
+	}
+	
+	@SuppressWarnings("checkstyle:parameternumber")
+	@PostMapping(path = Url.ADD_IMAGE_SERIES_PAGE, params = "!imageUrl")
+	public String processImage(
+		@Validated({
+			AddImageForm.RequireImageCheck.class,
+			AddImageForm.ImageChecks.class })
+		AddImageForm form,
+		BindingResult result,
+		@PathVariable("id") Integer seriesId,
+		Model model,
+		@CurrentUser Integer currentUserId,
+		Locale userLocale,
+		HttpServletRequest request,
 		HttpServletResponse response)
 		throws IOException {
 		
@@ -288,6 +321,8 @@ public class SeriesController {
 			response.sendError(HttpServletResponse.SC_NOT_FOUND);
 			return null;
 		}
+		
+		loadErrorsFromDownloadInterceptor(form, result, request);
 		
 		boolean maxQuantityOfImagesExceeded = !isAdmin() && !isAllowedToAddingImages(series);
 		model.addAttribute("maxQuantityOfImagesExceeded", maxQuantityOfImagesExceeded);

--- a/src/main/java/ru/mystamps/web/controller/TestController.java
+++ b/src/main/java/ru/mystamps/web/controller/TestController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.controller;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import ru.mystamps.web.Url;
+
+@Controller
+public class TestController {
+	
+	@GetMapping("/test/invalid/response-301")
+	public void redirect(HttpServletResponse response) {
+		response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+		response.setHeader("Location", Url.SITE);
+	}
+	
+	@GetMapping("/test/invalid/response-400")
+	public void badRequest(HttpServletResponse response) throws IOException {
+		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+	}
+	
+	@GetMapping("/test/invalid/response-404")
+	public void notFound(HttpServletResponse response) throws IOException {
+		response.sendError(HttpServletResponse.SC_NOT_FOUND);
+	}
+	
+	@GetMapping("/test/invalid/empty-jpeg-file")
+	public void emptyJpegFile(HttpServletResponse response) {
+		response.setContentType("image/jpeg");
+		response.setContentLength(0);
+	}
+	
+	@GetMapping(path = "/test/invalid/not-image-file", produces = "application/json")
+	@ResponseBody
+	public String simpleJson() {
+		return "test";
+	}
+	
+}

--- a/src/main/java/ru/mystamps/web/controller/dto/AddSeriesForm.java
+++ b/src/main/java/ru/mystamps/web/controller/dto/AddSeriesForm.java
@@ -25,7 +25,10 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.hibernate.validator.constraints.Range;
+import org.hibernate.validator.constraints.URL;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -37,6 +40,7 @@ import ru.mystamps.web.controller.converter.annotation.Country;
 import ru.mystamps.web.dao.dto.LinkEntityDto;
 import ru.mystamps.web.service.dto.AddSeriesDto;
 import ru.mystamps.web.support.beanvalidation.CatalogNumbers;
+import ru.mystamps.web.support.beanvalidation.HasImageOrImageUrl;
 import ru.mystamps.web.support.beanvalidation.ImageFile;
 import ru.mystamps.web.support.beanvalidation.MaxFileSize;
 import ru.mystamps.web.support.beanvalidation.MaxFileSize.Unit;
@@ -45,6 +49,7 @@ import ru.mystamps.web.support.beanvalidation.NotEmptyFilename;
 import ru.mystamps.web.support.beanvalidation.NotNullIfFirstField;
 import ru.mystamps.web.support.beanvalidation.Price;
 import ru.mystamps.web.support.beanvalidation.ReleaseDateIsNotInFuture;
+import ru.mystamps.web.support.beanvalidation.RequireImageOrImageUrl;
 
 import static ru.mystamps.web.validation.ValidationRules.MAX_DAYS_IN_MONTH;
 import static ru.mystamps.web.validation.ValidationRules.MAX_IMAGE_SIZE;
@@ -58,6 +63,7 @@ import static ru.mystamps.web.validation.ValidationRules.MIN_STAMPS_IN_SERIES;
 @Setter
 // TODO: combine price with currency to separate class
 @SuppressWarnings({ "PMD.TooManyFields", "PMD.AvoidDuplicateLiterals" })
+@RequireImageOrImageUrl(groups = AddSeriesForm.ImageUrl1Checks.class)
 @NotNullIfFirstField.List({
 	@NotNullIfFirstField(
 		first = "month", second = "year", message = "{month.requires.year}",
@@ -69,7 +75,7 @@ import static ru.mystamps.web.validation.ValidationRules.MIN_STAMPS_IN_SERIES;
 	)
 })
 @ReleaseDateIsNotInFuture(groups = AddSeriesForm.ReleaseDate3Checks.class)
-public class AddSeriesForm implements AddSeriesDto {
+public class AddSeriesForm implements AddSeriesDto, HasImageOrImageUrl {
 	
 	// FIXME: change type to plain Integer
 	@NotNull
@@ -128,13 +134,48 @@ public class AddSeriesForm implements AddSeriesDto {
 	@Size(max = MAX_SERIES_COMMENT_LENGTH, message = "{value.too-long}")
 	private String comment;
 	
-	@NotNull
-	@NotEmptyFilename(groups = Image1Checks.class)
-	@NotEmptyFile(groups = Image2Checks.class)
-	@MaxFileSize(value = MAX_IMAGE_SIZE, unit = Unit.Kbytes, groups = Image3Checks.class)
-	@ImageFile(groups = Image3Checks.class)
+	// Name of this field should match with the value of
+	// DownloadImageInterceptor.UPLOADED_IMAGE_FIELD_NAME.
+	@NotEmptyFilename(groups = RequireImageCheck.class)
+	@NotEmptyFile(groups = Image1Checks.class)
+	@MaxFileSize(value = MAX_IMAGE_SIZE, unit = Unit.Kbytes, groups = Image2Checks.class)
+	@ImageFile(groups = Image2Checks.class)
 	private MultipartFile image;
 	
+	// Name of this field must match with the value of DownloadImageInterceptor.URL_PARAMETER_NAME.
+	@URL(groups = ImageUrl2Checks.class)
+	private String imageUrl;
+	
+	// This field holds a file that was downloaded from imageUrl.
+	// Name of this field must match with the value of
+	// DownloadImageInterceptor.DOWNLOADED_IMAGE_FIELD_NAME.
+	@NotEmptyFile(groups = Image1Checks.class)
+	@MaxFileSize(value = MAX_IMAGE_SIZE, unit = Unit.Kbytes, groups = Image2Checks.class)
+	@ImageFile(groups = Image2Checks.class)
+	private MultipartFile downloadedImage;
+	
+	@Override
+	public MultipartFile getImage() {
+		if (hasImage()) {
+			return image;
+		}
+		
+		return downloadedImage;
+	}
+	
+	// This method has to be implemented to satisfy HasImageOrImageUrl requirements.
+	// The latter is being used by RequireImageOrImageUrl validator.
+	@Override
+	public boolean hasImage() {
+		return image != null && StringUtils.isNotEmpty(image.getOriginalFilename());
+	}
+	
+	// This method has to be implemented to satisfy HasImageOrImageUrl requirements.
+	// The latter is being used by RequireImageOrImageUrl validator.
+	@Override
+	public boolean hasImageUrl() {
+		return StringUtils.isNotEmpty(imageUrl);
+	}
 	
 	@GroupSequence({
 		ReleaseDate1Checks.class,
@@ -153,10 +194,25 @@ public class AddSeriesForm implements AddSeriesDto {
 	public interface ReleaseDate3Checks {
 	}
 	
+	public interface RequireImageCheck {
+	}
+	
+	@GroupSequence({
+		ImageUrl1Checks.class,
+		ImageUrl2Checks.class,
+	})
+	public interface ImageUrlChecks {
+	}
+	
+	public interface ImageUrl1Checks {
+	}
+	
+	public interface ImageUrl2Checks {
+	}
+	
 	@GroupSequence({
 		Image1Checks.class,
-		Image2Checks.class,
-		Image3Checks.class
+		Image2Checks.class
 	})
 	public interface ImageChecks {
 	}
@@ -165,9 +221,6 @@ public class AddSeriesForm implements AddSeriesDto {
 	}
 	
 	public interface Image2Checks {
-	}
-	
-	public interface Image3Checks {
 	}
 	
 }

--- a/src/main/java/ru/mystamps/web/controller/dto/AddSeriesForm.java
+++ b/src/main/java/ru/mystamps/web/controller/dto/AddSeriesForm.java
@@ -75,7 +75,7 @@ import static ru.mystamps.web.validation.ValidationRules.MIN_STAMPS_IN_SERIES;
 	)
 })
 @ReleaseDateIsNotInFuture(groups = AddSeriesForm.ReleaseDate3Checks.class)
-public class AddSeriesForm implements AddSeriesDto, HasImageOrImageUrl {
+public class AddSeriesForm implements AddSeriesDto, HasImageOrImageUrl, NullableImageUrl {
 	
 	// FIXME: change type to plain Integer
 	@NotNull

--- a/src/main/java/ru/mystamps/web/controller/dto/NullableImageUrl.java
+++ b/src/main/java/ru/mystamps/web/controller/dto/NullableImageUrl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.controller.dto;
+
+/**
+ * Interface of the form that has image URL field and supports its zeroed.
+ */
+public interface NullableImageUrl {
+	void setImageUrl(String url);
+	
+	default void nullifyImageUrl() {
+		setImageUrl(null);
+	}
+}

--- a/src/main/java/ru/mystamps/web/controller/interceptor/ByteArrayMultipartFile.java
+++ b/src/main/java/ru/mystamps/web/controller/interceptor/ByteArrayMultipartFile.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.controller.interceptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+class ByteArrayMultipartFile implements MultipartFile {
+	private final byte[] content;
+	private final String contentType;
+	private final String link;
+
+	@Override
+	public String getName() {
+		throw new IllegalStateException("Not implemented");
+	}
+
+	@Override
+	public String getOriginalFilename() {
+		return link;
+	}
+
+	@Override
+	public String getContentType() {
+		return contentType;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return getSize() == 0;
+	}
+
+	@Override
+	public long getSize() {
+		if (content == null) {
+			return 0;
+		}
+		return content.length;
+	}
+
+	@Override
+	public byte[] getBytes() throws IOException {
+		return content; // NOPMD: MethodReturnsInternalArray
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return new ByteArrayInputStream(content);
+	}
+
+	@Override
+	public void transferTo(File dest) throws IOException, IllegalStateException {
+		// Default mode is: CREATE, WRITE, and TRUNCATE_EXISTING.
+		// To prevent unexpected rewriting of existing file, we're overriding this behavior by
+		// explicitly specifying options.
+		Files.write(
+			dest.toPath(),
+			content,
+			StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE
+		);
+	}
+}

--- a/src/main/java/ru/mystamps/web/controller/interceptor/DownloadImageInterceptor.java
+++ b/src/main/java/ru/mystamps/web/controller/interceptor/DownloadImageInterceptor.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.controller.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.support.StandardMultipartHttpServletRequest;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import lombok.RequiredArgsConstructor;
+
+import ru.mystamps.web.service.DownloaderService;
+import ru.mystamps.web.service.dto.DownloadResult;
+import ru.mystamps.web.support.spring.security.Authority;
+import ru.mystamps.web.support.spring.security.SecurityContextUtils;
+
+/**
+ * Converts image URL to an image by downloading it from a server and binding to a form field.
+ *
+ * It handles only POST requests.
+ */
+@RequiredArgsConstructor
+public class DownloadImageInterceptor extends HandlerInterceptorAdapter {
+	
+	/**
+	 * Field name that contains image URL.
+	 */
+	public static final String URL_PARAMETER_NAME = "imageUrl";
+	
+	/**
+	 * Field name to which a downloaded image will be bound.
+	 */
+	public static final String DOWNLOADED_IMAGE_FIELD_NAME = "downloadedImage";
+	
+	/**
+	 * Field name of the image that is uploaded by a user.
+	 *
+	 * When it's present, we won't download an image from URL because a user should choose only one
+	 * image source.
+	 */
+	public static final String UPLOADED_IMAGE_FIELD_NAME = "image";
+	
+	/**
+	 * Name of request attribute, that will be used for storing an error code.
+	 *
+	 * To check whether an error has occurred, you can retrieve this attribute within a controller.
+	 * When it's not {@code null}, it has the code in the format of fully-qualified name
+	 * of the member of the {@link DownloadResult} enum.
+	 */
+	public static final String ERROR_CODE_ATTR_NAME = "DownloadedImage.ErrorCode";
+	
+	private static final Logger LOG = LoggerFactory.getLogger(DownloadImageInterceptor.class);
+	
+	private final DownloaderService downloaderService;
+	
+	@Override
+	@SuppressWarnings("PMD.SignatureDeclareThrowsException")
+	public boolean preHandle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		Object handler) throws Exception {
+		
+		if (!HttpMethod.POST.matches(request.getMethod())) {
+			return true;
+		}
+		
+		// If the field doesn't have a value, then nothing to do here.
+		String imageUrl = StringUtils.trimToEmpty(request.getParameter(URL_PARAMETER_NAME));
+		if (StringUtils.isEmpty(imageUrl)) {
+			return true;
+		}
+		
+		if (!(request instanceof StandardMultipartHttpServletRequest)) {
+			LOG.warn(
+				"Unknown type of request ({}). "
+				+ "Downloading images from external servers won't work!",
+				request
+			);
+			return true;
+		}
+		
+		StandardMultipartHttpServletRequest multipartRequest =
+			(StandardMultipartHttpServletRequest)request;
+		
+		// Minor optimization: we don't try to download a file if we know that user also uploads its
+		// own file. This case also will be validated by a controller and user will see an error.
+		MultipartFile image = multipartRequest.getFile(UPLOADED_IMAGE_FIELD_NAME);
+		if (image != null && StringUtils.isNotEmpty(image.getOriginalFilename())) {
+			return true;
+		}
+		
+		if (!SecurityContextUtils.hasAuthority(Authority.DOWNLOAD_IMAGE)) {
+			// TODO(security): fix possible log injection
+			LOG.warn(
+				"A user #{} without permissions has tried to download a file from '{}'",
+				SecurityContextUtils.getUserId(),
+				imageUrl
+			);
+			request.setAttribute(
+				ERROR_CODE_ATTR_NAME,
+				DownloadResult.Code.INSUFFICIENT_PERMISSIONS
+			);
+			return true;
+		}
+		
+		// A user has specified an image URL: we should download a file and represent it as a field.
+		// Later we'll validate this file in a controller.
+		DownloadResult result = downloaderService.download(imageUrl);
+		if (result.hasFailed()) {
+			request.setAttribute(ERROR_CODE_ATTR_NAME, result.getCode());
+			return true;
+		}
+		
+		MultipartFile downloadedImage =
+			new ByteArrayMultipartFile(result.getData(), result.getContentType(), imageUrl);
+		
+		multipartRequest.getMultiFileMap().set(DOWNLOADED_IMAGE_FIELD_NAME, downloadedImage);
+		
+		return true;
+	}
+	
+}

--- a/src/main/java/ru/mystamps/web/controller/interceptor/package-info.java
+++ b/src/main/java/ru/mystamps/web/controller/interceptor/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring MVC interceptors that allow to intercept requests and executing some logic before
+ * getting into the controllers.
+ */
+package ru.mystamps.web.controller.interceptor;

--- a/src/main/java/ru/mystamps/web/service/DownloaderService.java
+++ b/src/main/java/ru/mystamps/web/service/DownloaderService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.service;
+
+import ru.mystamps.web.service.dto.DownloadResult;
+
+public interface DownloaderService {
+	DownloadResult download(String url);
+}

--- a/src/main/java/ru/mystamps/web/service/HttpURLConnectionDownloaderService.java
+++ b/src/main/java/ru/mystamps/web/service/HttpURLConnectionDownloaderService.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.service;
+
+import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.util.StreamUtils;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import lombok.RequiredArgsConstructor;
+
+import ru.mystamps.web.service.dto.DownloadResult;
+import ru.mystamps.web.service.dto.DownloadResult.Code;
+import ru.mystamps.web.support.spring.security.HasAuthority;
+
+@RequiredArgsConstructor
+public class HttpURLConnectionDownloaderService implements DownloaderService {
+	
+	private static final Logger LOG =
+		LoggerFactory.getLogger(HttpURLConnectionDownloaderService.class);
+	
+	// We don't support redirects because they allow to bypass some of our validations.
+	// TODO: How exactly redirects can harm?
+	@SuppressWarnings({"PMD.RedundantFieldInitializer", "PMD.ImmutableField"})
+	private boolean followRedirects = false;
+	
+	// Only types listed here will be downloaded. For other types, INVALID_FILE_TYPE error
+	// will be returned. An empty array (or null) means that all types are allowed.
+	// TODO: at this moment we do a case sensitive comparison. Should we change it?
+	private final String[] allowedContentTypes;
+	
+	@Override
+	@PreAuthorize(HasAuthority.DOWNLOAD_IMAGE)
+	public DownloadResult download(String fileUrl) {
+		// TODO(security): fix possible log injection
+		LOG.debug("Downloading '{}'", fileUrl);
+		
+		try {
+			URL url = new URL(fileUrl);
+			
+			HttpURLConnection conn = openConnection(url);
+			if (conn == null) {
+				return DownloadResult.failed(Code.UNEXPECTED_ERROR);
+			}
+			
+			configureUserAgent(conn);
+			configureTimeouts(conn);
+			configureRedirects(conn);
+			
+			Code connectionResult = connect(conn);
+			if (connectionResult != Code.SUCCESS) {
+				return DownloadResult.failed(connectionResult);
+			}
+			
+			try (InputStream stream = new BufferedInputStream(conn.getInputStream())) {
+				Code validationResult = validateConnection(conn);
+				if (validationResult != Code.SUCCESS) {
+					return DownloadResult.failed(validationResult);
+				}
+				
+				// TODO(java9): use InputStream.readAllBytes()
+				byte[] data = StreamUtils.copyToByteArray(stream);
+				String contentType = conn.getContentType();
+				return DownloadResult.succeeded(data, contentType);
+				
+			} catch (FileNotFoundException ignored) {
+				LOG.debug("Couldn't download file: not found on the server");
+				return DownloadResult.failed(Code.FILE_NOT_FOUND);
+			}
+			
+		} catch (MalformedURLException ex) {
+			LOG.error("Couldn't download file: invalid URL: {}", ex.getMessage());
+			return DownloadResult.failed(Code.INVALID_URL);
+
+		} catch (IOException ex) {
+			LOG.warn("Couldn't download file", ex);
+			return DownloadResult.failed(Code.UNEXPECTED_ERROR);
+		}
+		
+	}
+	
+	private static HttpURLConnection openConnection(URL url) throws IOException {
+		URLConnection connection = url.openConnection();
+		if (!(connection instanceof HttpURLConnection)) {
+			LOG.warn(
+				"Couldn't open connection: "
+				+ "unknown type of connection class ({}). "
+				+ "Downloading images from external servers won't work!",
+				connection
+			);
+			return null;
+		}
+
+		return (HttpURLConnection)connection;
+	}
+	
+	private static void configureUserAgent(URLConnection conn) {
+		// TODO: make it configurable
+		conn.setRequestProperty(
+			"User-Agent",
+			"Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0"
+		);
+	}
+	
+	private static void configureTimeouts(URLConnection conn) {
+		// TODO: make it configurable
+		int timeout = Math.toIntExact(TimeUnit.SECONDS.toMillis(1));
+		conn.setConnectTimeout(timeout);
+		conn.setReadTimeout(timeout);
+	}
+	
+	private void configureRedirects(HttpURLConnection conn) {
+		conn.setInstanceFollowRedirects(followRedirects);
+	}
+	
+	private static Code connect(HttpURLConnection conn) {
+		try {
+			conn.connect();
+			return Code.SUCCESS;
+		
+		} catch (ConnectException ignored) {
+			LOG.debug("Couldn't download file: connect() has failed");
+			return Code.UNEXPECTED_ERROR;
+		
+		} catch (IOException ex) {
+			LOG.debug("Couldn't download file: connect() has failed", ex);
+			return Code.UNEXPECTED_ERROR;
+		}
+	}
+	
+	private Code validateConnection(HttpURLConnection conn) throws IOException {
+		int status = conn.getResponseCode();
+		if (status == HttpURLConnection.HTTP_MOVED_TEMP
+			|| status == HttpURLConnection.HTTP_MOVED_PERM) {
+			if (!followRedirects) {
+				LOG.debug("Couldn't download file: redirects are disallowed");
+				return Code.INVALID_REDIRECT;
+			}
+			
+		} else if (status != HttpURLConnection.HTTP_OK) {
+			LOG.debug("Couldn't download file: unexpected response status {}", status);
+			return Code.UNEXPECTED_ERROR;
+		}
+		
+		String contentType = conn.getContentType();
+		if (allowedContentTypes != null && !ArrayUtils.contains(allowedContentTypes, contentType)) {
+			// TODO(security): fix possible log injection
+			LOG.debug("Couldn't download file: unsupported file type '{}'", contentType);
+			return Code.INVALID_FILE_TYPE;
+		}
+		
+		// TODO: content length can be -1 for gzipped responses
+		// TODO: add protection against huge files
+		int contentLength = conn.getContentLength();
+		if (contentLength < 0) {
+			// TODO(security): fix possible log injection
+			LOG.debug("Couldn't download file: invalid Content-Length: {}", contentLength);
+			return Code.INVALID_FILE_SIZE;
+		}
+		
+		return Code.SUCCESS;
+	}
+	
+}

--- a/src/main/java/ru/mystamps/web/service/dto/DownloadResult.java
+++ b/src/main/java/ru/mystamps/web/service/dto/DownloadResult.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.service.dto;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class DownloadResult {
+	private final Code code;
+	private final byte[] data;
+	private final String contentType;
+	
+	public static DownloadResult failed(Code code) {
+		return new DownloadResult(code, ArrayUtils.EMPTY_BYTE_ARRAY, StringUtils.EMPTY);
+	}
+	
+	public static DownloadResult succeeded(byte[] data, String contentType) {
+		return new DownloadResult(Code.SUCCESS, data, contentType);
+	}
+	
+	public boolean hasFailed() {
+		return code != Code.SUCCESS;
+	}
+	
+	public enum Code {
+		SUCCESS,
+		INVALID_URL,
+		INVALID_REDIRECT,
+		INVALID_FILE_TYPE,
+		INVALID_FILE_SIZE,
+		FILE_NOT_FOUND,
+		INSUFFICIENT_PERMISSIONS,
+		UNEXPECTED_ERROR,
+	}
+	
+}

--- a/src/main/java/ru/mystamps/web/support/beanvalidation/HasImageOrImageUrl.java
+++ b/src/main/java/ru/mystamps/web/support/beanvalidation/HasImageOrImageUrl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.support.beanvalidation;
+
+/**
+ * Interface of the form that can be validated by {@link RequireImageOrImageUrl} validator.
+ */
+public interface HasImageOrImageUrl {
+	
+	/**
+	 * Checks whether an image was submitted.
+	 * @return true if user uploading an image
+	 */
+	boolean hasImage();
+
+	/**
+	 * Checks whether an image URL was specified.
+	 * @return true if user specified an image URL
+	 */
+	boolean hasImageUrl();
+}

--- a/src/main/java/ru/mystamps/web/support/beanvalidation/RequireImageOrImageUrl.java
+++ b/src/main/java/ru/mystamps/web/support/beanvalidation/RequireImageOrImageUrl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.support.beanvalidation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Validates that an image or an image URL is specified but not both.
+ *
+ * In order to be validated by this validator, target form must implement the
+ * {@link HasImageOrImageUrl} interface.
+ */
+@Target({ TYPE, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = RequireImageOrImageUrlValidator.class)
+@Documented
+public @interface RequireImageOrImageUrl {
+	// CheckStyle: ignore LineLength for next 1 line
+	String message() default "{ru.mystamps.web.support.beanvalidation.RequireImageOrImageUrl.message}";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/ru/mystamps/web/support/beanvalidation/RequireImageOrImageUrlValidator.java
+++ b/src/main/java/ru/mystamps/web/support/beanvalidation/RequireImageOrImageUrlValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2009-2017 Slava Semushin <slava.semushin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ru.mystamps.web.support.beanvalidation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Implementation of the {@link RequireImageOrImageUrl} validator.
+ *
+ * If an image and an image URL fields are empty, it marks both fields as having an error.
+ * If both fields were filled it also marks them as having an error.
+ */
+public class RequireImageOrImageUrlValidator
+	implements ConstraintValidator<RequireImageOrImageUrl, HasImageOrImageUrl> {
+	
+	@Override
+	public void initialize(RequireImageOrImageUrl annotation) {
+		// Intentionally empty: nothing to initialize
+	}
+	
+	@Override
+	public boolean isValid(HasImageOrImageUrl value, ConstraintValidatorContext ctx) {
+		
+		if (value == null) {
+			return true;
+		}
+
+		boolean hasImage    = value.hasImage();
+		boolean hasImageUrl = value.hasImageUrl();
+		
+		if (hasImage && !hasImageUrl) {
+			return true;
+		}
+
+		if (hasImageUrl && !hasImage) {
+			return true;
+		}
+
+		// mark both fields as having an error
+		// CheckStyle: ignore LineLength for next 1 line
+		ConstraintViolationUtils.recreate(ctx, "imageUrl", ctx.getDefaultConstraintMessageTemplate());
+		ConstraintViolationUtils.recreate(ctx, "image", ctx.getDefaultConstraintMessageTemplate());
+		
+		return false;
+	}
+	
+}
+

--- a/src/main/java/ru/mystamps/web/support/spring/security/Authority.java
+++ b/src/main/java/ru/mystamps/web/support/spring/security/Authority.java
@@ -30,6 +30,7 @@ public final class Authority {
 	public static final GrantedAuthority CREATE_CATEGORY        = new SimpleGrantedAuthority(StringAuthority.CREATE_CATEGORY);
 	public static final GrantedAuthority CREATE_COUNTRY         = new SimpleGrantedAuthority(StringAuthority.CREATE_COUNTRY);
 	public static final GrantedAuthority CREATE_SERIES          = new SimpleGrantedAuthority(StringAuthority.CREATE_SERIES);
+	public static final GrantedAuthority DOWNLOAD_IMAGE         = new SimpleGrantedAuthority(StringAuthority.DOWNLOAD_IMAGE);
 	public static final GrantedAuthority UPDATE_COLLECTION      = new SimpleGrantedAuthority(StringAuthority.UPDATE_COLLECTION);
 	public static final GrantedAuthority VIEW_SITE_EVENTS       = new SimpleGrantedAuthority(StringAuthority.VIEW_SITE_EVENTS);
 	public static final GrantedAuthority VIEW_SERIES_SALES      = new SimpleGrantedAuthority(StringAuthority.VIEW_SERIES_SALES);

--- a/src/main/java/ru/mystamps/web/support/spring/security/CustomUserDetailsService.java
+++ b/src/main/java/ru/mystamps/web/support/spring/security/CustomUserDetailsService.java
@@ -79,6 +79,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 			authorities.add(Authority.VIEW_SITE_EVENTS);
 			authorities.add(Authority.ADD_PARTICIPANT);
 			authorities.add(Authority.ADD_SERIES_SALES);
+			authorities.add(Authority.DOWNLOAD_IMAGE);
 			authorities.add(Authority.VIEW_SERIES_SALES);
 			authorities.add(Authority.MANAGE_TOGGLZ);
 			authorities.add(Authority.VIEW_DAILY_STATS);

--- a/src/main/java/ru/mystamps/web/support/spring/security/HasAuthority.java
+++ b/src/main/java/ru/mystamps/web/support/spring/security/HasAuthority.java
@@ -24,6 +24,7 @@ public final class HasAuthority {
 	public static final String CREATE_SERIES = "hasAuthority('" + StringAuthority.CREATE_SERIES + "')";
 	public static final String CREATE_CATEGORY = "hasAuthority('" + StringAuthority.CREATE_CATEGORY + "')";
 	public static final String CREATE_COUNTRY = "hasAuthority('" + StringAuthority.CREATE_COUNTRY + "')";
+	public static final String DOWNLOAD_IMAGE = "hasAuthority('" + StringAuthority.DOWNLOAD_IMAGE + "')";
 	public static final String VIEW_DAILY_STATS = "hasAuthority('" + StringAuthority.VIEW_DAILY_STATS + "')";
 	public static final String UPDATE_COLLECTION = "hasAuthority('" + StringAuthority.UPDATE_COLLECTION + "')";
 	public static final String VIEW_SITE_EVENTS = "hasAuthority('" + StringAuthority.VIEW_SITE_EVENTS + "')";

--- a/src/main/java/ru/mystamps/web/support/spring/security/StringAuthority.java
+++ b/src/main/java/ru/mystamps/web/support/spring/security/StringAuthority.java
@@ -26,6 +26,7 @@ public final class StringAuthority {
 	public static final String CREATE_CATEGORY        = "CREATE_CATEGORY";
 	public static final String CREATE_COUNTRY         = "CREATE_COUNTRY";
 	public static final String CREATE_SERIES          = "CREATE_SERIES";
+	public static final String DOWNLOAD_IMAGE         = "DOWNLOAD_IMAGE";
 	public static final String UPDATE_COLLECTION      = "UPDATE_COLLECTION";
 	public static final String VIEW_SITE_EVENTS       = "VIEW_SITE_EVENTS";
 	public static final String VIEW_SERIES_SALES      = "VIEW_SERIES_SALES";

--- a/src/main/resources/ru/mystamps/i18n/Messages.properties
+++ b/src/main/resources/ru/mystamps/i18n/Messages.properties
@@ -118,6 +118,7 @@ t_sg = Gibbons
 t_add_comment = Add comment
 t_comment = Comment
 t_image = Image
+t_image_url = Image URL
 t_add_more_images_hint = Later you will be able to add additional images
 t_not_chosen = Not chosen
 t_create_category_hint = You can also <a tabindex="-1" href="{0}">add a new category</a>

--- a/src/main/resources/ru/mystamps/i18n/Messages_ru.properties
+++ b/src/main/resources/ru/mystamps/i18n/Messages_ru.properties
@@ -118,6 +118,7 @@ t_sg = Gibbons
 t_add_comment = Добавить комментарий
 t_comment = Комментарий
 t_image = Изображение
+t_image_url = Ссылка на изображение
 t_add_more_images_hint = Вы сможете добавить дополнительные изображения позже
 t_not_chosen = Не выбрана
 t_create_category_hint = Вы также можете <a tabindex="-1" href="{0}">добавить новую категорию</a>

--- a/src/main/resources/ru/mystamps/i18n/ValidationMessages.properties
+++ b/src/main/resources/ru/mystamps/i18n/ValidationMessages.properties
@@ -23,6 +23,14 @@ ru.mystamps.web.support.beanvalidation.NotNullIfFirstField.message = Field '{sec
 ru.mystamps.web.support.beanvalidation.Price.message = Invalid value
 ru.mystamps.web.support.beanvalidation.ImageFile.message = Cannot detect file type. Must be image in JPEG or PNG format
 ru.mystamps.web.support.beanvalidation.MaxFileSize.message = File size must be not greater than {value} ${unit.name()}
+ru.mystamps.web.support.beanvalidation.RequireImageOrImageUrl.message = Image or image URL must be specified
+
+ru.mystamps.web.service.dto.DownloadResult.INVALID_URL = Invalid URL
+ru.mystamps.web.service.dto.DownloadResult.INVALID_REDIRECT = URL must not redirect to another address
+ru.mystamps.web.service.dto.DownloadResult.INVALID_FILE_TYPE = Invalid file type
+ru.mystamps.web.service.dto.DownloadResult.INVALID_FILE_SIZE = Invalid file size
+ru.mystamps.web.service.dto.DownloadResult.FILE_NOT_FOUND = File not found
+ru.mystamps.web.service.dto.DownloadResult.UNEXPECTED_ERROR = Could not download file
 
 value.too-short = Value is less than allowable minimum of {min} characters
 value.too-long = Value is greater than allowable maximum of {max} characters

--- a/src/main/resources/ru/mystamps/i18n/ValidationMessages_ru.properties
+++ b/src/main/resources/ru/mystamps/i18n/ValidationMessages_ru.properties
@@ -23,6 +23,14 @@ ru.mystamps.web.support.beanvalidation.NotNullIfFirstField.message = Поле '{
 ru.mystamps.web.support.beanvalidation.Price.message = Некорректное значение
 ru.mystamps.web.support.beanvalidation.ImageFile.message = Не удалось определить тип файла. Должен быть изображением в формате JPEG или PNG
 ru.mystamps.web.support.beanvalidation.MaxFileSize.message = Размер файла должен быть не более {value} ${unit.name().equals('Mbytes') ? 'Мбайт' : unit.name().equals('Kbytes') ? 'Кбайт' : 'байт'}
+ru.mystamps.web.support.beanvalidation.RequireImageOrImageUrl.message = Необходимо выбрать изображение либо указать ссылку на него
+
+ru.mystamps.web.service.dto.DownloadResult.INVALID_URL = Неправильный URL
+ru.mystamps.web.service.dto.DownloadResult.INVALID_REDIRECT = URL не должен перенаправлять на другой адрес
+ru.mystamps.web.service.dto.DownloadResult.INVALID_FILE_TYPE = Недопустимый тип файла
+ru.mystamps.web.service.dto.DownloadResult.INVALID_FILE_SIZE = Недопустимый размер файла
+ru.mystamps.web.service.dto.DownloadResult.FILE_NOT_FOUND = Файл не найден
+ru.mystamps.web.service.dto.DownloadResult.UNEXPECTED_ERROR = Не удалось скачать файл
 
 value.too-short = Значение должно быть не менее {min} символов
 value.too-long = Значение должно быть не более {max} символов

--- a/src/main/scripts/ci/check-build-and-verify.sh
+++ b/src/main/scripts/ci/check-build-and-verify.sh
@@ -140,7 +140,7 @@ if [ "$RUN_ONLY_INTEGRATION_TESTS" = 'no' ]; then
 	print_status "$BOOTLINT_STATUS" 'Run bootlint'
 	
 	if [ "$RFLINT_STATUS" != 'skip' ]; then
-		rflint --error=all --ignore TooFewKeywordSteps --ignore TooManyTestSteps --configure LineTooLong:130 src/test/robotframework \
+		rflint --error=all --ignore TooFewKeywordSteps --ignore TooManyTestSteps --ignore TooManyTestCases --configure LineTooLong:130 src/test/robotframework \
 			>rflint.log 2>&1 || RFLINT_STATUS=fail
 	fi
 	print_status "$RFLINT_STATUS" 'Run robot framework lint'

--- a/src/main/webapp/WEB-INF/views/series/add.html
+++ b/src/main/webapp/WEB-INF/views/series/add.html
@@ -227,10 +227,17 @@
 								<span th:remove="tag" th:text="#{t_image}">
 									Image
 								</span>
-								<span class="required_field">*</span>
+								<!--/*/
+								<span class="required_field" th:if="${not #authorization.expression('hasAuthority(''DOWNLOAD_IMAGE'')')}">*</span>
+								/*/-->
 							</label>
 							<div class="col-sm-7">
-								<input type="file" id="image" style="box-shadow: none; border: 0px;" required="required" accept="image/png,image/jpeg" th:field="*{image}" />
+								<input id="image"
+									type="file"
+									style="box-shadow: none; border: 0px;"
+									accept="image/png,image/jpeg"
+									th:field="*{image}"
+									th:attr="required=${#authorization.expression('hasAuthority(''DOWNLOAD_IMAGE'')') ? null : 'required'}" />
 								<small togglz:active="ADD_ADDITIONAL_IMAGES_TO_SERIES" sec:authorize="hasAuthority('ADD_IMAGES_TO_SERIES')">
 									<span class="hint-block" th:text="#{t_add_more_images_hint}">
 										Later you will be able to add additional images
@@ -238,6 +245,23 @@
 								</small>
 								<!--/*/
 								<span id="image.errors" class="help-block" th:if="${#fields.hasErrors('image')}" th:each="error : ${#fields.errors('image')}" th:text="${error}"></span>
+								/*/-->
+							</div>
+						</div>
+						
+						<div class="form-group form-group-sm"
+							th:classappend="${#fields.hasErrors('imageUrl') or #fields.hasErrors('downloadedImage') ? 'has-error' : ''}"
+							sec:authorize="hasAuthority('DOWNLOAD_IMAGE')">
+							<label for="image-url" class="control-label col-sm-3">
+								<span class="field-label" th:text="#{t_image_url}">
+									Image URL
+								</span>
+							</label>
+							<div class="col-sm-5">
+								<input type="url" id="image-url" class="form-control" th:field="*{imageUrl}" />
+								<!--/*/
+								<span id="image-url.errors" class="help-block" th:if="${#fields.hasErrors('imageUrl')}" th:each="error : ${#fields.errors('imageUrl')}" th:text="${error}"></span>
+								<span id="image-url.errors" class="help-block" th:if="${#fields.hasErrors('downloadedImage')}" th:each="error : ${#fields.errors('downloadedImage')}" th:text="${error}"></span>
 								/*/-->
 							</div>
 						</div>

--- a/src/main/webapp/WEB-INF/views/series/info.html
+++ b/src/main/webapp/WEB-INF/views/series/info.html
@@ -86,21 +86,30 @@
 							</div>
 							
 							<div class="row" th:if="${allowAddingImages}" togglz:active="ADD_ADDITIONAL_IMAGES_TO_SERIES">
-								<div class="col-sm-8 col-sm-offset-2">
+								<div class="col-sm-10">
 									<form id="add-image-form"
 										method="post"
 										class="form-horizontal"
 										enctype="multipart/form-data"
 										th:action="@{${ADD_IMAGE_SERIES_PAGE}(id=${series.id})}"
 										th:object="${addImageForm}">
-										<div class="form-group" th:classappend="${#fields.hasErrors('image') ? 'has-error' : ''}">
-											<input type="file" id="image" style="box-shadow: none; border: 0px;" required="required" accept="image/png,image/jpeg" th:field="*{image}" />
-											<!--/*/
-											<span id="image.errors" class="help-block" th:if="${#fields.hasErrors('image')}" th:each="error : ${#fields.errors('image')}" th:text="${error}"></span>
-											/*/-->
+										<div class="form-group form-group-sm" th:classappend="${#fields.hasErrors('image') ? 'has-error' : ''}">
+											<label for="image" class="control-label col-sm-3">
+												<span th:remove="tag" th:text="#{t_image}">
+													Image
+												</span>
+											</label>
+											<div class="col-sm-9">
+												<input type="file" id="image" style="box-shadow: none; border: 0px;" required="required" accept="image/png,image/jpeg" th:field="*{image}" />
+												<!--/*/
+												<span id="image.errors" class="help-block" th:if="${#fields.hasErrors('image')}" th:each="error : ${#fields.errors('image')}" th:text="${error}"></span>
+												/*/-->
+											</div>
 										</div>
-										<div class="from-group-sm">
-											<input type="submit" class="btn btn-primary" value="Add image" th:value="#{t_add_image}" />
+										<div class="form-group  from-group-sm">
+											<div class="col-sm-offset-3 col-sm-5">
+												<input type="submit" class="btn btn-primary" value="Add image" th:value="#{t_add_image}" />
+											</div>
 										</div>
 									</form>
 								</div>

--- a/src/main/webapp/WEB-INF/views/series/info.html
+++ b/src/main/webapp/WEB-INF/views/series/info.html
@@ -100,9 +100,30 @@
 												</span>
 											</label>
 											<div class="col-sm-9">
-												<input type="file" id="image" style="box-shadow: none; border: 0px;" required="required" accept="image/png,image/jpeg" th:field="*{image}" />
+												<input id="image"
+													type="file"
+													style="box-shadow: none; border: 0px;"
+													accept="image/png,image/jpeg"
+													th:field="*{image}"
+													th:attr="required=${#authorization.expression('hasAuthority(''DOWNLOAD_IMAGE'')') ? null : 'required'}" />
 												<!--/*/
 												<span id="image.errors" class="help-block" th:if="${#fields.hasErrors('image')}" th:each="error : ${#fields.errors('image')}" th:text="${error}"></span>
+												/*/-->
+											</div>
+										</div>
+										<div class="form-group form-group-sm"
+											th:classappend="${#fields.hasErrors('imageUrl') or #fields.hasErrors('downloadedImage') ? 'has-error' : ''}"
+											sec:authorize="hasAuthority('DOWNLOAD_IMAGE')">
+											<label for="image-url" class="control-label col-sm-3">
+												<span class="field-label" th:text="#{t_image_url}">
+													Image URL
+												</span>
+											</label>
+											<div class="col-sm-9">
+												<input type="url" id="image-url" class="form-control" th:field="*{imageUrl}" />
+												<!--/*/
+												<span id="image-url.errors" class="help-block" th:if="${#fields.hasErrors('imageUrl')}" th:each="error : ${#fields.errors('imageUrl')}" th:text="${error}"></span>
+												<span id="image-url.errors" class="help-block" th:if="${#fields.hasErrors('downloadedImage')}" th:each="error : ${#fields.errors('downloadedImage')}" th:text="${error}"></span>
 												/*/-->
 											</div>
 										</div>

--- a/src/test/groovy/ru/mystamps/web/service/SeriesServiceImplTest.groovy
+++ b/src/test/groovy/ru/mystamps/web/service/SeriesServiceImplTest.groovy
@@ -55,6 +55,7 @@ class SeriesServiceImplTest extends Specification {
 	private AddImageForm imageForm
 	private Integer userId
 	
+	@SuppressWarnings('UnnecessaryGetter')
 	def setup() {
 		form = new AddSeriesForm()
 		form.setQuantity(2)
@@ -76,6 +77,8 @@ class SeriesServiceImplTest extends Specification {
 			yvertCatalogService,
 			gibbonsCatalogService
 		)
+		
+		multipartFile.getOriginalFilename() >> '/path/to/test/file.ext'
 	}
 	
 	//

--- a/src/test/java/ru/mystamps/web/tests/page/AddSeriesPage.java
+++ b/src/test/java/ru/mystamps/web/tests/page/AddSeriesPage.java
@@ -79,7 +79,7 @@ public class AddSeriesPage extends AbstractPageWithForm {
 				inputField("gibbonsNumbers"),
 				inputField("gibbonsPrice"),
 				textareaField("comment").accessibleByAll(false),
-				required(uploadFileField("image"))
+				uploadFileField("image")
 			)
 			.and()
 			.with(submitButton(tr("t_add")))

--- a/src/test/robotframework/series/add-image/logic.robot
+++ b/src/test/robotframework/series/add-image/logic.robot
@@ -8,13 +8,21 @@ Test Setup       Before Test
 Force Tags       series  add-image  logic
 
 *** Test Cases ***
-Add additional image
-	[Documentation]                Verify adding an additional image to a series
+Add additional image by providing a file
+	[Documentation]                Verify uploading an additional image to a series
 	Page Should Not Contain Image  id=series-image-2
 	Choose File                    id=image  ${MAIN_RESOURCE_DIR}${/}test.png
 	Submit Form                    id=add-image-form
 	Location Should Be             ${SITE_URL}/series/1
 	Page Should Contain Image      id=series-image-2
+
+Add additional image by providing a URL to image
+	[Documentation]                Verify downloading an additional image to a series
+	Page Should Not Contain Image  id=series-image-3
+	Input Text                     id=image-url  ${SITE_URL}/image/1
+	Submit Form                    id=add-image-form
+	Location Should Be             ${SITE_URL}/series/1
+	Page Should Contain Image      id=series-image-3
 
 *** Keywords ***
 Before Test Suite

--- a/src/test/robotframework/series/add-image/validation.robot
+++ b/src/test/robotframework/series/add-image/validation.robot
@@ -7,16 +7,55 @@ Suite Teardown   After Test Suite
 Force Tags       series  add-image  validation
 
 *** Test Cases ***
-Add image but without filling a required field
-	[Documentation]         Verify validation of a required field
+Add image with empty required fields
+	[Documentation]         Verify validation of mandatory fields
 	Submit Form             id=add-image-form
-	Element Text Should Be  id=image.errors  Value must not be empty
+	Element Text Should Be  id=image.errors      Image or image URL must be specified
+	Element Text Should Be  id=image-url.errors  Image or image URL must be specified
 
 Add image with empty file
 	[Documentation]         Verify validation of an empty file
 	Choose File             id=image  ${TEST_RESOURCE_DIR}${/}empty.png
 	Submit Form             id=add-image-form
 	Element Text Should Be  id=image.errors  File must not be empty
+
+Add image with both image and an image URL
+	[Documentation]         Verify validation of an image and an image URL provided at the same time
+	Choose File             id=image      ${MAIN_RESOURCE_DIR}${/}test.png
+	Input Text              id=image-url  ${SITE_URL}/image/1
+	Submit Form             id=add-image-form
+	Element Text Should Be  id=image.errors      Image or image URL must be specified
+	Element Text Should Be  id=image-url.errors  Image or image URL must be specified
+
+Add image with image URL with invalid response
+	[Documentation]         Verify validation of invalid response from a server
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-400
+	Submit Form             id=add-image-form
+	Element Text Should Be  id=image-url.errors  Could not download file
+
+Add image with image URL to a file that does not exist
+	[Documentation]         Verify validation of URL to non existing file
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-404
+	Submit Form             id=add-image-form
+	Element Text Should Be  id=image-url.errors  File not found
+
+Add image with image URL that causes a redirect
+	[Documentation]         Verify validation of URL with redirect
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-301
+	Submit Form             id=add-image-form
+	Element Text Should Be  id=image-url.errors  URL must not redirect to another address
+
+Add image with image URL to an empty file
+	[Documentation]         Verify validation of URL to an empty file
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/empty-jpeg-file
+	Submit Form             id=add-image-form
+	Element Text Should Be  id=image-url.errors  File must not be empty
+
+Add image with image URL to not an image file
+	[Documentation]         Verify validation of URL to a file of unsupported type
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/not-image-file
+	Submit Form             id=add-image-form
+	Element Text Should Be  id=image-url.errors  Invalid file type
 
 *** Keywords ***
 Before Test Suite

--- a/src/test/robotframework/series/add-image/validation.robot
+++ b/src/test/robotframework/series/add-image/validation.robot
@@ -27,6 +27,12 @@ Add image with both image and an image URL
 	Element Text Should Be  id=image.errors      Image or image URL must be specified
 	Element Text Should Be  id=image-url.errors  Image or image URL must be specified
 
+Add image with invalid URL
+	[Documentation]         Verify validation of invalid URL
+	Input Text              id=image-url  invalid-url
+	Submit Form             id=add-image-form
+	Element Text Should Be  id=image-url.errors  Value must be a valid URL
+
 Add image with image URL with invalid response
 	[Documentation]         Verify validation of invalid response from a server
 	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-400

--- a/src/test/robotframework/series/creation/logic.robot
+++ b/src/test/robotframework/series/creation/logic.robot
@@ -8,8 +8,8 @@ Test Setup       Before Test
 Force Tags       series  logic
 
 *** Test Cases ***
-Create series by filling only required fields
-	[Documentation]            Verify creation of series by filling only mandatory fields
+Create series by filling only required fields and providing an image
+	[Documentation]            Verify creation of series by filling only mandatory fields (with image)
 	Select From List By Label  id=category  Sport
 	Input Text                 id=quantity  2
 	Choose File                id=image  ${MAIN_RESOURCE_DIR}${/}test.png
@@ -18,6 +18,19 @@ Create series by filling only required fields
 	Should Match Regexp        ${location}  /series/\\d+
 	Element Text Should Be     id=category_name  Sport
 	Element Text Should Be     id=quantity  2
+	Element Text Should Be     id=perforated  Yes
+	Page Should Contain Image  id=series-image-1
+
+Create series by filling only required fields and providing a URL to image
+	[Documentation]            Verify creation of series by filling only mandatory fields (with an image URL)
+	Select From List By Label  id=category  Sport
+	Input Text                 id=quantity  1
+	Input Text                 id=image-url  ${SITE_URL}/image/1
+	Submit Form                id=add-series-form
+	${location}=               Get Location
+	Should Match Regexp        ${location}  /series/\\d+
+	Element Text Should Be     id=category_name  Sport
+	Element Text Should Be     id=quantity  1
 	Element Text Should Be     id=perforated  Yes
 	Page Should Contain Image  id=series-image-1
 

--- a/src/test/robotframework/series/creation/validation-user.robot
+++ b/src/test/robotframework/series/creation/validation-user.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Documentation    Verify series creation validation scenarios from a user
+Library          Selenium2Library
+Suite Setup      Before Test Suite
+Suite Teardown   After Test Suite
+Force Tags       series  validation
+
+*** Test Cases ***
+Create series with empty required fields
+	[Documentation]                  Verify validation of mandatory fields
+	Submit Form                      id=add-series-form
+	Element Text Should Be           id=category.errors  Value must not be empty
+	Element Text Should Be           id=quantity.errors  Value must not be empty
+	Element Text Should Be           id=image.errors     Value must not be empty
+	Page Should Not Contain Element  id=image-url.errors
+
+*** Keywords ***
+Before Test Suite
+	[Documentation]                     Login as a user and go to create series page
+	Open Browser                        ${SITE_URL}  ${BROWSER}
+	Register Keyword To Run On Failure  Log Source
+	Log In As                           login=coder  password=test
+	Go To                               ${SITE_URL}/series/add
+
+After Test Suite
+	[Documentation]  Log out and close browser
+	Log Out
+	Close Browser
+
+Log In As
+	[Documentation]  Log in as a user
+	[Arguments]      ${login}  ${password}
+	Go To            ${SITE_URL}/account/auth
+	Input Text       id=login  ${login}
+	Input Password   id=password  ${password}
+	Submit Form      id=auth-account-form
+
+Log Out
+	[Documentation]  Log out current user
+	Submit Form      id=logout-form

--- a/src/test/robotframework/series/creation/validation.robot
+++ b/src/test/robotframework/series/creation/validation.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation    Verify series creation validation scenarios
+Documentation    Verify series creation validation scenarios from admin
 Library          Selenium2Library
 Resource         ../../auth.steps.robot
 Suite Setup      Before Test Suite
@@ -7,6 +7,14 @@ Suite Teardown   After Test Suite
 Force Tags       series  validation
 
 *** Test Cases ***
+Create series with empty required fields
+	[Documentation]         Verify validation of mandatory fields
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=category.errors  Value must not be empty
+	Element Text Should Be  id=quantity.errors  Value must not be empty
+	Element Text Should Be  id=image.errors      Image or image URL must be specified
+	Element Text Should Be  id=image-url.errors  Image or image URL must be specified
+
 Create series with non-numeric quantity
 	[Documentation]         Verify validation of non-numeric quantity
 	Input Text              id=quantity  NaN
@@ -30,6 +38,44 @@ Create series with empty image
 	Choose File             id=image  ${TEST_RESOURCE_DIR}${/}empty.png
 	Submit Form             id=add-series-form
 	Element Text Should Be  id=image.errors  File must not be empty
+
+Create series with both image and an image URL
+	[Documentation]         Verify validation of an image and an image URL provided at the same time
+	Choose File             id=image      ${MAIN_RESOURCE_DIR}${/}test.png
+	Input Text              id=image-url  ${SITE_URL}/image/1
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=image.errors      Image or image URL must be specified
+	Element Text Should Be  id=image-url.errors  Image or image URL must be specified
+
+Create series with image URL with invalid response
+	[Documentation]         Verify validation of invalid response from a server
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-400
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=image-url.errors  Could not download file
+
+Create series with image URL to a file that does not exist
+	[Documentation]         Verify validation of URL to non existing file
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-404
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=image-url.errors  File not found
+
+Create series with image URL that causes a redirect
+	[Documentation]         Verify validation of URL with redirect
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-301
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=image-url.errors  URL must not redirect to another address
+
+Create series with image URL to an empty file
+	[Documentation]         Verify validation of URL to an empty file
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/empty-jpeg-file
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=image-url.errors  File must not be empty
+
+Create series with image URL to not an image file
+	[Documentation]         Verify validation of URL to a file of unsupported type
+	Input Text              id=image-url  ${SITE_URL}/test/invalid/not-image-file
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=image-url.errors  Invalid file type
 
 Catalog numbers should reject invalid values
 	[Documentation]  Verify that fields with catalog numbers reject invalid values

--- a/src/test/robotframework/series/creation/validation.robot
+++ b/src/test/robotframework/series/creation/validation.robot
@@ -47,6 +47,12 @@ Create series with both image and an image URL
 	Element Text Should Be  id=image.errors      Image or image URL must be specified
 	Element Text Should Be  id=image-url.errors  Image or image URL must be specified
 
+Create series with invalid image URL
+	[Documentation]         Verify validation of invalid URL
+	Input Text              id=image-url  invalid-url
+	Submit Form             id=add-series-form
+	Element Text Should Be  id=image-url.errors  Value must be a valid URL
+
 Create series with image URL with invalid response
 	[Documentation]         Verify validation of invalid response from a server
 	Input Text              id=image-url  ${SITE_URL}/test/invalid/response-400


### PR DESCRIPTION
TODO:
- [x] fix integration tests
- [x] fix errors from static analysis tools
- [x] show errors near the URL field
- [x] show errors that has happened during file downloading
- [x] add title to field that only HTTP protocol is supported and no redirects are allowed
- [x] `MyMultipartFile`: preserve original content type
- [x] fix 2 error messages for invalid protocol
- [x] add localization for errors from interceptor
- [x] add localization for `@URL` validator
- [x] validation: `image` or `imageUrl` must be specified
- [x] validation: `image` and `imageUrl` cannot be specified at the same time
- [x] `DownloadImageInterceptor`: make URLs and fields configurable
- [x] extract downloader to a service
- [x] implement for `/series/{id}` page
- [x] Handle `HttpURLConnection.HTTP_MOVED_TEMP || status == HttpURLConnection.HTTP_MOVED_PERM` separately
- [x] invoke setConnectTimeout() ?
- [x] add acceptance tests
  - [x] user specifies image as URL (http://127.0.0.1:8080/image/1)
  - [x] user specifies image as URL to an empty file (error expected)
  - [x] user specifies image as URL to a file of unsupported type (error expected)
  - [x] user specifies image as URL to a file that doesn't exist (error expected)
  - [x] user specifies image as URL that causes redirect (error expected)
  - [x] user specifies image as URL but the file couldn't be downloaded (error expected)
- [x] replace togglz by authority
- [x] fix validation: when user doesn't have perms he see the error "Image or image URL must be specified" instead of "Required field"
- [x] update changelog
- [x] add a test: user should have required image field with error "Required field"
- [x] add a test: admin should have required image and image url fields with error "Image or image URL must be specified"
- [x] consider what to do with `@NotEmptyFilename` validator

Addressed to #199