### PR TITLE
Fix DataIntegrityViolationException when we import a series

### DIFF
--- a/src/main/resources/liquibase/version/0.4.xml
+++ b/src/main/resources/liquibase/version/0.4.xml
@@ -57,5 +57,6 @@
 	<include file="0.4/2018-10-16--similar_series.xml" relativeToChangelogFile="true"/>
 	<include file="0.4/2018-12-03--site_parsers.xml" relativeToChangelogFile="true"/>
 	<include file="0.4/2018-12-20--nullify_currency_without_price.xml" relativeToChangelogFile="true"/>
+	<include file="0.4/2019-04-19--series_sales_transaction_url_length.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/liquibase/version/0.4/2019-04-19--series_sales_transaction_url_length.xml
+++ b/src/main/resources/liquibase/version/0.4/2019-04-19--series_sales_transaction_url_length.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+		xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+	
+	<changeSet id="modify-series_sales-transaction_url-field" author="mihnayan" context="scheme">
+		<!--
+			Fix DataIntegrityViolationException when we import a series with a URL longer than 255 characters.
+			The size of the column is made to correspond the size of the `series_import_requests.url` column.
+		-->
+		<modifyDataType tableName="series_sales" columnName="transaction_url" newDataType="VARCHAR(767)" />
+	</changeSet>
+	
+</databaseChangeLog>


### PR DESCRIPTION
Fix DataIntegrityViolationException when we import a series with a URL longer than 255 characters.

Addressed to #990