### PR TITLE
Switch RobotFramework tests to Python in order to unbreak them for HTMX-powered pages

### DIFF
--- a/.github/workflows/integration-tests-h2.yml
+++ b/.github/workflows/integration-tests-h2.yml
@@ -54,11 +54,46 @@ jobs:
           # Whether to configure the token or SSH key with the local git config. Default: true
           persist-credentials: false
 
+      - name: Install mise to set up tools
+        uses: jdx/mise-action@v3.5.1 # https://github.com/jdx/mise-action
+        with:
+          version: 2025.11.11                # [default: latest] mise version to install
+          install: true                    # [default: true] run `mise install`
+          cache: true                      # [default: true] cache mise using GitHub's cache
+          log_level: info                  # [default: info] log level
+          working_directory: .             # [default: .] directory to run mise in
+        env:
+          # Workaround: don't install some dependencies that we don't want (java)
+          # See: https://github.com/jdx/mise-action/issues/183
+          # https://mise.jdx.dev/configuration/settings.html#disable_tools
+          MISE_DISABLE_TOOLS: java
+
       - name: Install JDK
         uses: actions/setup-java@v5.1.0 # https://github.com/actions/setup-java
         with:
           distribution: 'adopt'                    # https://github.com/actions/setup-java#supported-distributions
           java-version: ${{ matrix.java-version }} # https://github.com/actions/setup-java#supported-version-syntax
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
+        with:
+          chrome-version: '145.0.7632.117' # Must match version in mise.toml
+          install-dependencies: false      # Default: false
+          install-chromedriver: false      # Default: false
+
+      - name: Install Robot Framework
+        run: pip install -r requirements.txt
+
+      # NOTE: robot --version returns 251 exit code
+      # See for details:
+      # - https://github.com/robotframework/robotframework/issues/5184
+      # - https://github.com/robotframework/robotframework/issues/3874
+      # - https://robotframework.org/robotframework/3.2.2/RobotFrameworkUserGuide.html#return-codes
+      - name: Show tools versions
+        run: |
+          robot --version || :
+          chrome --version
+          chromedriver --version
 
       - name: Restore existing cache
         uses: actions/cache@v5.0.2 # https://github.com/actions/cache

--- a/.github/workflows/integration-tests-h2.yml
+++ b/.github/workflows/integration-tests-h2.yml
@@ -74,6 +74,9 @@ jobs:
           distribution: 'adopt'                    # https://github.com/actions/setup-java#supported-distributions
           java-version: ${{ matrix.java-version }} # https://github.com/actions/setup-java#supported-version-syntax
 
+      - name: Show java version before
+        run: java -version
+
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
         id: setup-chrome
@@ -81,6 +84,11 @@ jobs:
           chrome-version: '147.0.7727.56' # Must match version in mise.toml
           install-dependencies: false      # Default: false
           install-chromedriver: false      # Default: false
+
+      - name: Show java version after
+        run: |
+          java -version
+          echo "$PATH"
 
       - name: Install Robot Framework
         run: pip install -r requirements.txt
@@ -100,7 +108,6 @@ jobs:
       # See: https://github.com/browser-actions/setup-chrome/issues/619
       - name: Override system Chrome
         run: |
-          echo "$PATH"
           set -x
           which chrome
           which google-chrome

--- a/.github/workflows/integration-tests-h2.yml
+++ b/.github/workflows/integration-tests-h2.yml
@@ -94,13 +94,19 @@ jobs:
         run: |
           robot --version || :
           chrome --version
-          google-chrome --version
           chromedriver --version
 
       # Workaround: chrome installed by setup-chrome clashes with chrome bundled with runner
       # See: https://github.com/browser-actions/setup-chrome/issues/619
       - name: Override system Chrome
-        run: sudo ln -svf ${{steps.setup-chrome.outputs.chrome-path}} /usr/bin/google-chrome
+        run: |
+          echo "$PATH"
+          set -x
+          which chrome
+          which google-chrome
+          google-chrome --version
+          sudo ln -svf ${{steps.setup-chrome.outputs.chrome-path}} /usr/bin/google-chrome
+          google-chrome --version
 
       - name: Restore existing cache
         uses: actions/cache@v5.0.2 # https://github.com/actions/cache

--- a/.github/workflows/integration-tests-h2.yml
+++ b/.github/workflows/integration-tests-h2.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
+        id: setup-chrome
         with:
           chrome-version: '147.0.7727.56' # Must match version in mise.toml
           install-dependencies: false      # Default: false
@@ -93,7 +94,13 @@ jobs:
         run: |
           robot --version || :
           chrome --version
+          google-chrome --version
           chromedriver --version
+
+      # Workaround: chrome installed by setup-chrome clashes with chrome bundled with runner
+      # See: https://github.com/browser-actions/setup-chrome/issues/619
+      - name: Override system Chrome
+        run: sudo ln -svf ${{steps.setup-chrome.outputs.chrome-path}} /usr/bin/google-chrome
 
       - name: Restore existing cache
         uses: actions/cache@v5.0.2 # https://github.com/actions/cache

--- a/.github/workflows/integration-tests-h2.yml
+++ b/.github/workflows/integration-tests-h2.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
         with:
-          chrome-version: '145.0.7632.117' # Must match version in mise.toml
+          chrome-version: '147.0.7727.56' # Must match version in mise.toml
           install-dependencies: false      # Default: false
           install-chromedriver: false      # Default: false
 

--- a/.github/workflows/integration-tests-mysql.yml
+++ b/.github/workflows/integration-tests-mysql.yml
@@ -1,18 +1,19 @@
 name: Integration Tests (MySQL)
 
 on:
-  push:
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
-    paths-ignore:
-      - '.gitignore'
-      - '.github/**'
-      - '!.github/workflows/integration-tests-mysql.yml'
-      - 'docs/**'
-      - 'infra/**'
-      - 'src/main/config/*'
-      - 'src/main/scripts/**'
-      - '!src/main/scripts/execute-command.sh'
-      - 'src/test/hurl/**'
+  workflow_dispatch:
+#  push:
+#    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
+#    paths-ignore:
+#      - '.gitignore'
+#      - '.github/**'
+#      - '!.github/workflows/integration-tests-mysql.yml'
+#      - 'docs/**'
+#      - 'infra/**'
+#      - 'src/main/config/*'
+#      - 'src/main/scripts/**'
+#      - '!src/main/scripts/execute-command.sh'
+#      - 'src/test/hurl/**'
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 permissions:

--- a/.github/workflows/integration-tests-mysql.yml
+++ b/.github/workflows/integration-tests-mysql.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
         with:
-          chrome-version: '145.0.7632.117' # Must match version in mise.toml
+          chrome-version: '147.0.7727.56' # Must match version in mise.toml
           install-dependencies: false      # Default: false
           install-chromedriver: false      # Default: false
 

--- a/.github/workflows/integration-tests-mysql.yml
+++ b/.github/workflows/integration-tests-mysql.yml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
+        id: setup-chrome
         with:
           chrome-version: '147.0.7727.56' # Must match version in mise.toml
           install-dependencies: false      # Default: false
@@ -103,7 +104,13 @@ jobs:
         run: |
           robot --version || :
           chrome --version
+          google-chrome --version
           chromedriver --version
+
+      # Workaround: chrome installed by setup-chrome clashes with chrome bundled with runner
+      # See: https://github.com/browser-actions/setup-chrome/issues/619
+      - name: Override system Chrome
+        run: sudo ln -svf ${{steps.setup-chrome.outputs.chrome-path}} /usr/bin/google-chrome
 
       - name: Restore existing cache
         uses: actions/cache@v5.0.2 # https://github.com/actions/cache

--- a/.github/workflows/integration-tests-mysql.yml
+++ b/.github/workflows/integration-tests-mysql.yml
@@ -64,11 +64,46 @@ jobs:
           # Whether to configure the token or SSH key with the local git config. Default: true
           persist-credentials: false
 
+      - name: Install mise to set up tools
+        uses: jdx/mise-action@v3.5.1 # https://github.com/jdx/mise-action
+        with:
+          version: 2025.11.11                # [default: latest] mise version to install
+          install: true                    # [default: true] run `mise install`
+          cache: true                      # [default: true] cache mise using GitHub's cache
+          log_level: info                  # [default: info] log level
+          working_directory: .             # [default: .] directory to run mise in
+        env:
+          # Workaround: don't install some dependencies that we don't want (java)
+          # See: https://github.com/jdx/mise-action/issues/183
+          # https://mise.jdx.dev/configuration/settings.html#disable_tools
+          MISE_DISABLE_TOOLS: java
+
       - name: Install JDK
         uses: actions/setup-java@v5.1.0 # https://github.com/actions/setup-java
         with:
           distribution: 'adopt' # https://github.com/actions/setup-java#supported-distributions
           java-version: '8'     # https://github.com/actions/setup-java#supported-version-syntax
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
+        with:
+          chrome-version: '145.0.7632.117' # Must match version in mise.toml
+          install-dependencies: false      # Default: false
+          install-chromedriver: false      # Default: false
+
+      - name: Install Robot Framework
+        run: pip install -r requirements.txt
+
+      # NOTE: robot --version returns 251 exit code
+      # See for details:
+      # - https://github.com/robotframework/robotframework/issues/5184
+      # - https://github.com/robotframework/robotframework/issues/3874
+      # - https://robotframework.org/robotframework/3.2.2/RobotFrameworkUserGuide.html#return-codes
+      - name: Show tools versions
+        run: |
+          robot --version || :
+          chrome --version
+          chromedriver --version
 
       - name: Restore existing cache
         uses: actions/cache@v5.0.2 # https://github.com/actions/cache

--- a/.github/workflows/integration-tests-postgres.yml
+++ b/.github/workflows/integration-tests-postgres.yml
@@ -55,11 +55,46 @@ jobs:
           # Whether to configure the token or SSH key with the local git config. Default: true
           persist-credentials: false
 
+      - name: Install mise to set up tools
+        uses: jdx/mise-action@v3.5.1 # https://github.com/jdx/mise-action
+        with:
+          version: 2025.11.11                # [default: latest] mise version to install
+          install: true                    # [default: true] run `mise install`
+          cache: true                      # [default: true] cache mise using GitHub's cache
+          log_level: info                  # [default: info] log level
+          working_directory: .             # [default: .] directory to run mise in
+        env:
+          # Workaround: don't install some dependencies that we don't want (java)
+          # See: https://github.com/jdx/mise-action/issues/183
+          # https://mise.jdx.dev/configuration/settings.html#disable_tools
+          MISE_DISABLE_TOOLS: java
+
       - name: Install JDK
         uses: actions/setup-java@v5.1.0 # https://github.com/actions/setup-java
         with:
           distribution: 'adopt' # https://github.com/actions/setup-java#supported-distributions
           java-version: '8'     # https://github.com/actions/setup-java#supported-version-syntax
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
+        with:
+          chrome-version: '145.0.7632.117' # Must match version in mise.toml
+          install-dependencies: false      # Default: false
+          install-chromedriver: false      # Default: false
+
+      - name: Install Robot Framework
+        run: pip install -r requirements.txt
+
+      # NOTE: robot --version returns 251 exit code
+      # See for details:
+      # - https://github.com/robotframework/robotframework/issues/5184
+      # - https://github.com/robotframework/robotframework/issues/3874
+      # - https://robotframework.org/robotframework/3.2.2/RobotFrameworkUserGuide.html#return-codes
+      - name: Show tools versions
+        run: |
+          robot --version || :
+          chrome --version
+          chromedriver --version
 
       - name: Restore existing cache
         uses: actions/cache@v5.0.2 # https://github.com/actions/cache

--- a/.github/workflows/integration-tests-postgres.yml
+++ b/.github/workflows/integration-tests-postgres.yml
@@ -1,18 +1,19 @@
 name: Integration Tests (PostgreSQL)
 
 on:
-  push:
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
-    paths-ignore:
-      - '.gitignore'
-      - '.github/**'
-      - '!.github/workflows/integration-tests-postgres.yml'
-      - 'docs/**'
-      - 'infra/**'
-      - 'src/main/config/*'
-      - 'src/main/scripts/**'
-      - '!src/main/scripts/execute-command.sh'
-      - 'src/test/hurl/**'
+  workflow_dispatch:
+#  push:
+#    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
+#    paths-ignore:
+#      - '.gitignore'
+#      - '.github/**'
+#      - '!.github/workflows/integration-tests-postgres.yml'
+#      - 'docs/**'
+#      - 'infra/**'
+#      - 'src/main/config/*'
+#      - 'src/main/scripts/**'
+#      - '!src/main/scripts/execute-command.sh'
+#      - 'src/test/hurl/**'
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 permissions:

--- a/.github/workflows/integration-tests-postgres.yml
+++ b/.github/workflows/integration-tests-postgres.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
+        id: setup-chrome
         with:
           chrome-version: '147.0.7727.56' # Must match version in mise.toml
           install-dependencies: false      # Default: false
@@ -94,7 +95,13 @@ jobs:
         run: |
           robot --version || :
           chrome --version
+          google-chrome --version
           chromedriver --version
+
+      # Workaround: chrome installed by setup-chrome clashes with chrome bundled with runner
+      # See: https://github.com/browser-actions/setup-chrome/issues/619
+      - name: Override system Chrome
+        run: sudo ln -svf ${{steps.setup-chrome.outputs.chrome-path}} /usr/bin/google-chrome
 
       - name: Restore existing cache
         uses: actions/cache@v5.0.2 # https://github.com/actions/cache

--- a/.github/workflows/integration-tests-postgres.yml
+++ b/.github/workflows/integration-tests-postgres.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2.1.1 # https://github.com/browser-actions/setup-chrome
         with:
-          chrome-version: '145.0.7632.117' # Must match version in mise.toml
+          chrome-version: '147.0.7727.56' # Must match version in mise.toml
           install-dependencies: false      # Default: false
           install-chromedriver: false      # Default: false
 

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,4 +1,1 @@
--Dorg.slf4j.simpleLogger.log.com.gargoylesoftware.htmlunit.DefaultCssErrorHandler=error
--Dorg.slf4j.simpleLogger.log.com.gargoylesoftware.htmlunit.html.DefaultElementFactory=warn
--Dorg.slf4j.simpleLogger.log.com.gargoylesoftware.htmlunit.IncorrectnessListenerImpl=error
 -Dorg.slf4j.simpleLogger.showLogName=false

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,11 @@
 java = "adoptopenjdk-8.0.442"
 maven = "3.9.12"
 
+# for integration tests
+python = "3.6.15"
+# must match version in .github/workflows/integration-tests-h2.yml
+chromedriver = "145.0.7632.117"
+
 #
 # Project tasks
 #

--- a/mise.toml
+++ b/mise.toml
@@ -4,8 +4,8 @@ maven = "3.9.12"
 
 # for integration tests
 python = "3.6.15"
-# must match version in .github/workflows/integration-tests-h2.yml
-chromedriver = "145.0.7632.117"
+# must match version in .github/workflows/integration-tests-*.yml
+chromedriver = "147.0.7727.56"
 
 #
 # Project tasks

--- a/pom.xml
+++ b/pom.xml
@@ -369,45 +369,6 @@
 			<scope>test</scope>
 		</dependency>
 		
-		<!-- Required for src/test/robotframework/account/registration/logic.robot -->
-		<dependency>
-			<groupId>com.github.hi-fi</groupId>
-			<artifactId>robotframework-httprequestlibrary</artifactId>
-			<version>0.0.15</version>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		
-		<dependency>
-			<groupId>com.github.hi-fi</groupId>
-			<artifactId>robotframework-seleniumlibrary</artifactId>
-			<version>3.141.59.26535</version>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>io.appium</groupId>
-					<artifactId>java-client</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>io.github.bonigarcia</groupId>
-					<artifactId>webdrivermanager</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>io.selendroid</groupId>
-					<artifactId>selendroid-client</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.machinepublishers</groupId>
-					<artifactId>jbrowserdriver</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		
 		<dependency>
 			<groupId>com.teketik</groupId>
 			<artifactId>spring-test-context-cache-limiter</artifactId>
@@ -448,27 +409,6 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<version>${junit-jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>htmlunit-driver</artifactId>
-			<version>${selenium-htmlunit.version}</version>
-			<scope>test</scope>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-api</artifactId>
-			<version>${selenium.version}</version>
-			<scope>test</scope>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-support</artifactId>
-			<version>${selenium.version}</version>
 			<scope>test</scope>
 		</dependency>
 		
@@ -562,7 +502,6 @@
 		<h2.version>2.2.224</h2.version>
 		<hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
 		<hikaricp.version>4.0.3</hikaricp.version>
-		<htmlunit.version>2.70.0</htmlunit.version>
 		<jakarta-mail.version>1.6.7</jakarta-mail.version>
 		<jakarta-validation.version>2.0.2</jakarta-validation.version>
 		<junit-jupiter.version>5.3.2</junit-jupiter.version>
@@ -577,8 +516,6 @@
 		<maven-war-plugin.version>3.5.1</maven-war-plugin.version>
 		<mysql.version>5.1.49</mysql.version>
 		<postgresql.version>9.4.1212.jre7</postgresql.version>
-		<selenium-htmlunit.version>2.70.0</selenium-htmlunit.version>
-		<selenium.version>3.141.59</selenium.version>
 		<servlet-api.version>4.0.1</servlet-api.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<!-- LATER: remove overriding once version from Spring Boot will match the used one  -->
@@ -898,7 +835,7 @@
 					<logLevel>DEBUG</logLevel>
 					-->
 					<variables>
-						<variable>BROWSER:htmlunitwithjs</variable>
+						<variable>BROWSER:headlesschrome</variable>
 						<variable>MAIN_RESOURCE_DIR:${basedir}/src/main/resources/test</variable>
 						<variable>TEST_RESOURCE_DIR:${basedir}/src/test/resources</variable>
 						<variable>MOCK_SERVER:http://127.0.0.1:8888</variable>
@@ -913,6 +850,9 @@
 						-->
 						<nonCriticalTag>htmx</nonCriticalTag>
 					</nonCriticalTags>
+					<externalRunner>
+						<runWithPython>true</runWithPython>
+					</externalRunner>
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -845,10 +845,6 @@
 					<nonCriticalTags>
 						<!-- Allow to tests with this tag to fail without changing final status -->
 						<nonCriticalTag>unstable</nonCriticalTag>
-						<!--
-							@todo #1671 Fix integration tests because of unsupported HTMX in htmlunit
-						-->
-						<nonCriticalTag>htmx</nonCriticalTag>
 					</nonCriticalTags>
 					<externalRunner>
 						<runWithPython>true</runWithPython>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Integration tests dependencies
+robotframework==3.2.2
+robotframework-seleniumlibrary==5.1.3
+robotframework-requests==0.8.2

--- a/src/main/java/ru/mystamps/web/feature/site/ResourceUrl.java
+++ b/src/main/java/ru/mystamps/web/feature/site/ResourceUrl.java
@@ -31,7 +31,7 @@ public final class ResourceUrl {
 	public static final String STATIC_RESOURCES_URL = "https://stamps.filezz.ru";
 	
 	// MUST be updated when any of our resources were modified
-	public static final String RESOURCES_VERSION = "v0.4.7.1";
+	public static final String RESOURCES_VERSION = "v0.4.7.2";
 
 	private static final String CATALOG_UTILS_JS      = "/public/js/" + RESOURCES_VERSION + "/utils/CatalogUtils.min.js";
 	private static final String COLLECTION_INFO_JS     = "/public/js/" + RESOURCES_VERSION + "/collection/info.min.js";

--- a/src/main/webapp/WEB-INF/static/styles/main.css
+++ b/src/main/webapp/WEB-INF/static/styles/main.css
@@ -173,3 +173,7 @@ label {
 		column-count: 5;
 	}
 }
+
+.total_price {
+	font-weight: bold;
+}

--- a/src/main/webapp/WEB-INF/views/collection/estimation.html
+++ b/src/main/webapp/WEB-INF/views/collection/estimation.html
@@ -118,7 +118,11 @@
 							<!--/* @todo #884 /collection/{slug}/estimation: optimize summing of prices */-->
 							<tr class="info">
 								<th th:text="|#{t_total}:|">Total:</th>
-								<th
+								<!--/*
+									Workaround for "Table Footer Should Contain" keyword from SeleniumLibrary that unable to find values within <th> tag.
+									See for details: https://github.com/robotframework/SeleniumLibrary/issues/1436
+								*/-->
+								<td style="font-weight: bold"
 									th:with="totalRub=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'RUB'].![price])},totalUsd=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'USD'].![price])},totalEur=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'EUR'].![price])},totalCzk=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'CZK'].![price])},totalByn=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'BYN'].![price])},totalUah=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'UAH'].![price])}">
 									<span th:text="|${totalRub} RUB|" th:if="${totalRub != null}" th:remove="tag">14.4 RUB</span>
 									<br th:if="${totalUsd != null and totalRub != null}" />
@@ -131,7 +135,7 @@
 									<span th:text="|${totalByn} BYN|" th:if="${totalByn != null}" th:remove="tag">130 BYN</span>
 									<br th:if="${totalUah != null and (totalRub != null or totalUsd != null or totalEur != null or totalCzk != null or totalByn != null)}" />
 									<span th:text="|${totalUah} UAH|" th:if="${totalUah != null}" th:remove="tag">200 UAH</span>
-								</th>
+								</td>
 							</tr>
 						</tfoot>
 					</table>

--- a/src/main/webapp/WEB-INF/views/collection/estimation.html
+++ b/src/main/webapp/WEB-INF/views/collection/estimation.html
@@ -122,7 +122,7 @@
 									Workaround for "Table Footer Should Contain" keyword from SeleniumLibrary that unable to find values within <th> tag.
 									See for details: https://github.com/robotframework/SeleniumLibrary/issues/1436
 								*/-->
-								<td style="font-weight: bold"
+								<td class="total_price"
 									th:with="totalRub=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'RUB'].![price])},totalUsd=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'USD'].![price])},totalEur=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'EUR'].![price])},totalCzk=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'CZK'].![price])},totalByn=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'BYN'].![price])},totalUah=${#aggregates.sum(seriesOfCollection.?[price != null and currency.toString() == 'UAH'].![price])}">
 									<span th:text="|${totalRub} RUB|" th:if="${totalRub != null}" th:remove="tag">14.4 RUB</span>
 									<br th:if="${totalUsd != null and totalRub != null}" />

--- a/src/test/robotframework/__init__.robot
+++ b/src/test/robotframework/__init__.robot
@@ -1,8 +1,9 @@
 *** Settings ***
 Documentation  Global Test Suites Configuration
 Library        SeleniumLibrary
+Resource       selenium.utils.robot
 Suite Setup    Before All Test Suites
 
 *** Keywords ***
 Before All Test Suites
-	Register Keyword To Run On Failure  Log Source
+	Register Keyword To Run On Failure  Save Screenshot and Log Source

--- a/src/test/robotframework/account/activation/logic.robot
+++ b/src/test/robotframework/account/activation/logic.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation   Verify account activation scenarios
 Library         SeleniumLibrary
+Resource        ../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
 Test Setup      Before Test

--- a/src/test/robotframework/account/activation/misc-user.robot
+++ b/src/test/robotframework/account/activation/misc-user.robot
@@ -2,6 +2,7 @@
 Documentation   Verify miscellaneous aspects of account activation from user
 Library         SeleniumLibrary
 Resource        ../../auth.steps.robot
+Resource        ../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
 Test Setup      Before Test

--- a/src/test/robotframework/account/authentication/logic.robot
+++ b/src/test/robotframework/account/authentication/logic.robot
@@ -12,7 +12,7 @@ Successful authentication
 	Submit Form                 id:auth-account-form
 	Location Should Be          ${SITE_URL}/
 	Page Should Contain Link    link:Test Suite
-	Page Should Contain Button  value:Sign out
+	Page Should Contain Button  Sign out
 
 Log out
 	Go To                     ${SITE_URL}/account/auth

--- a/src/test/robotframework/account/registration/logic.robot
+++ b/src/test/robotframework/account/registration/logic.robot
@@ -9,7 +9,6 @@ Force Tags      account  registration  logic
 
 *** Test Cases ***
 After account creation an e-mail with activation link should be send
-	[Tags]                  unstable
 	Input Text              id:email  coder@rock.home
 	Submit Form             id:register-account-form
 	Element Text Should Be  id:msg-success  Instructions to finish registration have been sent to your e-mail
@@ -33,6 +32,6 @@ Search For Request
 	Create Session    mailserver  ${MOCK_SERVER}
 	# See http://wiremock.org/docs/verifying/
 	${response}=      Post Request  mailserver  /__admin/requests/find  data=${requestSignature}
-	Log               ${response.json}
-	Length Should Be  ${response.json['requests']}  1
-	[Return]          ${response.json['requests']}
+	Log               ${response.json()}
+	Length Should Be  ${response.json()['requests']}  1
+	[Return]          ${response.json()['requests']}

--- a/src/test/robotframework/account/registration/logic.robot
+++ b/src/test/robotframework/account/registration/logic.robot
@@ -2,7 +2,7 @@
 Documentation   Verify account registration scenario
 Library         String
 Library         SeleniumLibrary
-Library         HttpRequestLibrary
+Library         RequestsLibrary
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
 Force Tags      account  registration  logic

--- a/src/test/robotframework/account/registration/misc-user.robot
+++ b/src/test/robotframework/account/registration/misc-user.robot
@@ -2,6 +2,7 @@
 Documentation   Verify miscellaneous aspects of account registration from user
 Library         SeleniumLibrary
 Resource        ../../auth.steps.robot
+Resource        ../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
 Test Setup      Before Test

--- a/src/test/robotframework/category/creation/misc.robot
+++ b/src/test/robotframework/category/creation/misc.robot
@@ -2,6 +2,7 @@
 Documentation    Verify miscellaneous aspects of category creation
 Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
+Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Force Tags       category  misc

--- a/src/test/robotframework/category/creation/validation.robot
+++ b/src/test/robotframework/category/creation/validation.robot
@@ -2,6 +2,7 @@
 Documentation    Verify category creation validation scenarios
 Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
+Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Force Tags       category  validation

--- a/src/test/robotframework/collection/add-series/logic.robot
+++ b/src/test/robotframework/collection/add-series/logic.robot
@@ -4,7 +4,7 @@ Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
-Force Tags       collection  series  logic  htmx
+Force Tags       collection  series  logic
 
 *** Test Cases ***
 Add a series to user's collection (all stamps)
@@ -18,21 +18,21 @@ Add a series to user's collection (all stamps)
 	Element Text Should Be     css:.image-gallery figcaption [href="/series/2"] ~ .label-success  New
 
 Add the same series to user's collection again (incomplete series)
-	Go To                       ${SITE_URL}/series/2
-	Element Text Should Be      id:series-status-msg  You already have this series. Add another one instance:
-	Input Text                  id:number-of-stamps  1
-	Submit Form                 id:add-series-form
+	Go To                        ${SITE_URL}/series/2
+	Element Text Should Be       id:series-status-msg  You already have this series. Add another one instance:
+	Input Text                   id:number-of-stamps  1
+	Submit Form                  id:add-series-form
 	# See https://stackoverflow.com/questions/1604471/how-can-i-find-an-element-by-css-class-with-xpath
-	${linkXpath}=               Catenate  SEPARATOR=
-	...                         //*[contains(concat(" ", normalize-space(@class), " "), " image-gallery ")]
-	...                         //figcaption
-	...                         //a[@href="/series/2"]
-	${successLabelElem}=        Set Variable  *[contains(concat(" ", normalize-space(@class), " "), " label-success ")]
-	Xpath Should Match X Times  xpath:${linkXpath}  expectedXpathCount=2
-	Xpath Should Match X Times  xpath:${linkXpath}/following-sibling::${successLabelElem}  expectedXpathCount=1
-	Element Text Should Be      css:.image-gallery figcaption [href="/series/2"] ~ .label-success  New
+	${linkXpath}=                Catenate  SEPARATOR=
+	...                          //*[contains(concat(" ", normalize-space(@class), " "), " image-gallery ")]
+	...                          //figcaption
+	...                          //a[@href="/series/2"]
+	${successLabelElem}=         Set Variable  *[contains(concat(" ", normalize-space(@class), " "), " label-success ")]
+	Page Should Contain Element  xpath:${linkXpath}  limit=2
+	Page Should Contain Element  xpath:${linkXpath}/following-sibling::${successLabelElem}  limit=1
+	Element Text Should Be       css:.image-gallery figcaption [href="/series/2"] ~ .label-success  New
 	# See https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator
-	Element Text Should Be      css:.image-gallery figcaption [href="/series/2"] ~ .label-default  1 out of 2
+	Element Text Should Be       css:.image-gallery figcaption [href="/series/2"] ~ .label-default  1 out of 2
 
 *** Keywords ***
 Before Test Suite

--- a/src/test/robotframework/collection/add-series/logic.robot
+++ b/src/test/robotframework/collection/add-series/logic.robot
@@ -9,14 +9,14 @@ Force Tags       collection  series  logic
 
 *** Test Cases ***
 Add a series to user's collection (all stamps)
-	Go To                      ${SITE_URL}/series/2
-	Element Text Should Be     id:series-status-msg  You don't have this series. Add one instance:
-	Textfield Value Should Be  id:number-of-stamps  2
-	Element Text Should Be     id:number-of-stamps-block  I have out of 2 stamps
-	Submit Form                id:add-series-form
-	Page Should Contain Link   css:.image-gallery figcaption [href="/series/2"]
+	Go To                             ${SITE_URL}/series/2
+	Element Text Should Be            id:series-status-msg  You don't have this series. Add one instance:
+	Textfield Value Should Be         id:number-of-stamps  2
+	Element Text Should Match Regexp  id:number-of-stamps-block  I have[\\n\\r]+out of 2 stamps
+	Submit Form                       id:add-series-form
+	Page Should Contain Link          css:.image-gallery figcaption [href="/series/2"]
 	# See https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator
-	Element Text Should Be     css:.image-gallery figcaption [href="/series/2"] ~ .label-success  New
+	Element Text Should Be            css:.image-gallery figcaption [href="/series/2"] ~ .label-success  New
 
 Add the same series to user's collection again (incomplete series)
 	Go To                        ${SITE_URL}/series/2

--- a/src/test/robotframework/collection/add-series/logic.robot
+++ b/src/test/robotframework/collection/add-series/logic.robot
@@ -12,7 +12,7 @@ Add a series to user's collection (all stamps)
 	Go To                             ${SITE_URL}/series/2
 	Element Text Should Be            id:series-status-msg  You don't have this series. Add one instance:
 	Textfield Value Should Be         id:number-of-stamps  2
-	Element Text Should Match Regexp  id:number-of-stamps-block  I have[\\n\\r]+out of 2 stamps
+	Element Text Should Match Regexp  id:number-of-stamps-block  I have[\\n \\r]+out of 2 stamps
 	Submit Form                       id:add-series-form
 	Page Should Contain Link          css:.image-gallery figcaption [href="/series/2"]
 	# See https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator

--- a/src/test/robotframework/collection/add-series/logic.robot
+++ b/src/test/robotframework/collection/add-series/logic.robot
@@ -2,6 +2,7 @@
 Documentation    Verify add series to user's collection
 Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
+Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Force Tags       collection  series  logic

--- a/src/test/robotframework/collection/add-series/validation-paid.robot
+++ b/src/test/robotframework/collection/add-series/validation-paid.robot
@@ -6,7 +6,7 @@ Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Disable Client Validation  add-series-form
-Force Tags       collection  validation  htmx
+Force Tags       collection  validation
 
 *** Test Cases ***
 Add a series with price but without currency

--- a/src/test/robotframework/collection/add-series/validation-user.robot
+++ b/src/test/robotframework/collection/add-series/validation-user.robot
@@ -6,7 +6,7 @@ Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Disable Client Validation  add-series-form
-Force Tags       collection  validation  htmx
+Force Tags       collection  validation
 
 *** Test Cases ***
 Add a series without required field

--- a/src/test/robotframework/collection/estimation/access.robot
+++ b/src/test/robotframework/collection/estimation/access.robot
@@ -2,6 +2,7 @@
 Documentation   Verify access to a collection estimation page
 Library         SeleniumLibrary
 Resource        ../../auth.steps.robot
+Resource        ../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
 Force Tags      collection  estimation  access

--- a/src/test/robotframework/collection/estimation/logic.robot
+++ b/src/test/robotframework/collection/estimation/logic.robot
@@ -13,21 +13,19 @@ Message should be shown when a collection is empty
 	Element Text Should Be  id:empty-collection-msg  In this collection is no stamps
 
 Series with its price should be taken into account
-	[Tags]                       htmx
 	Go To                        ${SITE_URL}/series/1
 	Input Text                   id:paid-price  100
 	Select From List By Value    id:paid-currency  ${expectedCurrency}
 	Submit Form                  id:add-series-form
 	Go To                        ${SITE_URL}/collection/paid/estimation
-	Table Cell Should Contain    collection-estimation  row=2  column=2  text=100.00 ${expectedCurrency}
+	Table Cell Should Contain    collection-estimation  row=2  column=2  expected=100.00 ${expectedCurrency}
 	Table Footer Should Contain  collection-estimation  100.00 ${expectedCurrency}
 
 Series without price should be shown but not taken into account
-	[Tags]                       htmx
 	Go To                        ${SITE_URL}/series/2
 	Submit Form                  id:add-series-form
 	Go To                        ${SITE_URL}/collection/paid/estimation
-	Table Cell Should Contain    collection-estimation  row=3  column=2  text=${EMPTY}
+	Table Cell Should Contain    collection-estimation  row=3  column=2  expected=${EMPTY}
 	Table Footer Should Contain  collection-estimation  100.00 ${expectedCurrency}
 
 *** Keywords ***

--- a/src/test/robotframework/collection/estimation/logic.robot
+++ b/src/test/robotframework/collection/estimation/logic.robot
@@ -18,15 +18,15 @@ Series with its price should be taken into account
 	Select From List By Value    id:paid-currency  ${expectedCurrency}
 	Submit Form                  id:add-series-form
 	Go To                        ${SITE_URL}/collection/paid/estimation
-	Table Cell Should Contain    collection-estimation  row=2  column=2  expected=100.00 ${expectedCurrency}
-	Table Footer Should Contain  collection-estimation  100.00 ${expectedCurrency}
+	Table Cell Should Contain    id:collection-estimation  row=2  column=2  expected=100.00 ${expectedCurrency}
+	Table Footer Should Contain  id:collection-estimation  100.00 ${expectedCurrency}
 
 Series without price should be shown but not taken into account
 	Go To                        ${SITE_URL}/series/2
 	Submit Form                  id:add-series-form
 	Go To                        ${SITE_URL}/collection/paid/estimation
-	Table Cell Should Contain    collection-estimation  row=3  column=2  expected=${EMPTY}
-	Table Footer Should Contain  collection-estimation  100.00 ${expectedCurrency}
+	Table Cell Should Contain    id:collection-estimation  row=3  column=2  expected=${EMPTY}
+	Table Footer Should Contain  id:collection-estimation  100.00 ${expectedCurrency}
 
 *** Keywords ***
 Before Test Suite

--- a/src/test/robotframework/collection/remove-series/logic.robot
+++ b/src/test/robotframework/collection/remove-series/logic.robot
@@ -4,21 +4,21 @@ Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
-Force Tags       collection  series  logic  htmx
+Force Tags       collection  series  logic
 
 *** Test Cases ***
 Remove the first instance of a series from user's collection
-	Go To                       ${SITE_URL}/series/3
-	Xpath Should Match X Times  xpath://input[@value="Remove from collection"]  expectedXpathCount=2
+	Go To                        ${SITE_URL}/series/3
+	Page Should Contain Element  xpath://input[@value="Remove from collection"]  limit=2
 	# Submit the first form
-	Submit Form                 css:.remove-series-form
-	Page Should Contain Link    css:.image-gallery figcaption [href="/series/3"]
+	Submit Form                  css:.remove-series-form
+	Page Should Contain Link     css:.image-gallery figcaption [href="/series/3"]
 	# See https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator
-	Element Text Should Be      css:.image-gallery figcaption [href="/series/3"] ~ .label-default  2 out of 3
+	Element Text Should Be       css:.image-gallery figcaption [href="/series/3"] ~ .label-default  2 out of 3
 
 Remove the last instance of a series from user's collection
 	Go To                         ${SITE_URL}/series/3
-	Xpath Should Match X Times    xpath://input[@value="Remove from collection"]  expectedXpathCount=1
+	Page Should Contain Element   xpath://input[@value="Remove from collection"]  limit=1
 	Element Text Should Be        css:.remove-series-form .label-default  2 out of 3
 	Submit Form                   css:.remove-series-form
 	Page Should Not Contain Link  css:[href="/series/3"]

--- a/src/test/robotframework/collection/remove-series/logic.robot
+++ b/src/test/robotframework/collection/remove-series/logic.robot
@@ -2,6 +2,7 @@
 Documentation    Verify series removal from a user's collection
 Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
+Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Force Tags       collection  series  logic

--- a/src/test/robotframework/country/creation/validation.robot
+++ b/src/test/robotframework/country/creation/validation.robot
@@ -2,6 +2,7 @@
 Documentation    Verify country creation validation scenarios
 Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
+Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Force Tags       country  validation

--- a/src/test/robotframework/participant/creation/logic.robot
+++ b/src/test/robotframework/participant/creation/logic.robot
@@ -3,6 +3,7 @@ Documentation    Verify participant creation scenarios
 Library          Collections
 Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
+Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Before Test

--- a/src/test/robotframework/participant/creation/logic.robot
+++ b/src/test/robotframework/participant/creation/logic.robot
@@ -6,7 +6,7 @@ Resource         ../../auth.steps.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Before Test
-Force Tags       participant  logic  htmx
+Force Tags       participant  logic
 
 *** Test Cases ***
 Create participant with name only (fill only mandatory fields)

--- a/src/test/robotframework/participant/creation/misc.robot
+++ b/src/test/robotframework/participant/creation/misc.robot
@@ -2,6 +2,7 @@
 Documentation    Verify miscellaneous aspects of participant creation
 Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
+Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Force Tags       participant  misc

--- a/src/test/robotframework/selenium.utils.robot
+++ b/src/test/robotframework/selenium.utils.robot
@@ -30,7 +30,7 @@ Country Field Should Have Option
 Link Should Point To
 	[Documentation]  Verify that "href" attribute of the element refers to a link
 	[Arguments]      ${locator}  ${expectedUrl}
-	${url}=          Get Element Attribute  ${locator}@href
+	${url}=          Get Element Attribute  ${locator}  href
 	Should Be Equal  ${expectedUrl}  ${url}
 
 # NOTE: this keyword should be used as a last resort. Prefer "Wait Until Page Contains Element"

--- a/src/test/robotframework/selenium.utils.robot
+++ b/src/test/robotframework/selenium.utils.robot
@@ -25,7 +25,7 @@ Country Field Should Have Option
 	Click Element                     id:country-selectized
 	${dropdownXpath}=                 Set Variable  //*[contains(@class, "selectize-dropdown-content")]
 	Wait Until Page Contains Element  xpath:${dropdownXpath}/*[contains(@class, "option")]
-	Xpath Should Match X Times        xpath:${dropdownXpath}/*[text() = "${value}"]  expectedXpathCount=1
+	Page Should Contain Element       xpath:${dropdownXpath}/*[text() = "${value}"]  limit=1
 
 Link Should Point To
 	[Documentation]  Verify that "href" attribute of the element refers to a link
@@ -51,7 +51,7 @@ Select Random Option From List
 	[Arguments]                ${locator}
 	${options}=                Get List Items  ${locator}
 	${size}=                   Get Length  ${options}
-	${randomIndex}=            Evaluate  random.randint(0, ${size}-1)  modules=random
+	${randomIndex}=            Evaluate  str(random.randint(0, ${size}-1))  modules=random
 	Select From List By Index  ${locator}  ${randomIndex}
 
 Disable Client Validation

--- a/src/test/robotframework/selenium.utils.robot
+++ b/src/test/robotframework/selenium.utils.robot
@@ -2,6 +2,10 @@
 Documentation  Keywords (and workarounds) that are missing in the SeleniumLibrary for Robot Framework
 
 *** Keywords ***
+Save Screenshot and Log Source
+	Capture Page Screenshot  EMBED
+	Log Source
+
 Element Text Should Match Regexp
 	[Documentation]      Verify the text of the element identified by locator matches the given pattern
 	[Arguments]          ${locator}  ${regexp}

--- a/src/test/robotframework/selenium.utils.robot
+++ b/src/test/robotframework/selenium.utils.robot
@@ -50,6 +50,17 @@ Wait Until Element Value Is
 	...                 ';
 	Wait For Condition  ${elemHasValue}
 
+Wait Until Element Text Is
+	[Documentation]     Hybrid of "Wait Until Page Contains Element" and "Element Text Should Be" keywords
+	[Arguments]         ${id}  ${text}
+	${elemHasText}=     Catenate  SEPARATOR=
+	...                 var el = window.document.getElementById('
+	...                 ${id}
+	...                 '); return el != null && el.innerText == '
+	...                 ${text}
+	...                 ';
+	Wait For Condition  ${elemHasText}
+
 Select Random Option From List
 	[Documentation]            Choose a random option from a select element
 	[Arguments]                ${locator}

--- a/src/test/robotframework/series/add-comment/logic.robot
+++ b/src/test/robotframework/series/add-comment/logic.robot
@@ -5,7 +5,7 @@ Resource        ../../auth.steps.robot
 Resource        ../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  add-comment  logic  htmx
+Force Tags      series  add-comment  logic
 
 *** Test Cases ***
 Add a comment

--- a/src/test/robotframework/series/add-comment/validation.robot
+++ b/src/test/robotframework/series/add-comment/validation.robot
@@ -9,23 +9,20 @@ Force Tags      series  add-comment  validation
 
 *** Test Cases ***
 Add comment with empty required field
-	[Setup]                           Disable Client Validation  add-comment-form
-	Submit Form                       id:add-comment-form
-	Wait Until Page Contains Element  id:new-comment.errors
-	Element Text Should Be            id:new-comment.errors  Value must not be empty
+	[Setup]                     Disable Client Validation  add-comment-form
+	Submit Form                 id:add-comment-form
+	Wait Until Element Text Is  new-comment.errors  Value must not be empty
 
 Add a blank comment
-	Input Text                        id:new-comment  ${SPACE}${SPACE}
-	Submit Form                       id:add-comment-form
-	Wait Until Page Contains Element  id:new-comment.errors
-	Element Text Should Be            id:new-comment.errors  Value must not be empty
+	Input Text                  id:new-comment  ${SPACE}${SPACE}
+	Submit Form                 id:add-comment-form
+	Wait Until Element Text Is  new-comment.errors  Value must not be empty
 
 Add too long comment
-	${letter}=                        Set Variable  x
-	Input Text                        id:new-comment  ${letter * 1025}
-	Submit Form                       id:add-comment-form
-	Wait Until Page Contains Element  id:new-comment.errors
-	Element Text Should Be            id:new-comment.errors  Value is greater than allowable maximum of 1024 characters
+	${letter}=                  Set Variable  x
+	Input Text                  id:new-comment  ${letter * 1025}
+	Submit Form                 id:add-comment-form
+	Wait Until Element Text Is  new-comment.errors  Value is greater than allowable maximum of 1024 characters
 
 *** Keywords ***
 Before Test Suite

--- a/src/test/robotframework/series/add-comment/validation.robot
+++ b/src/test/robotframework/series/add-comment/validation.robot
@@ -29,6 +29,7 @@ Add too long comment
 
 *** Keywords ***
 Before Test Suite
-	Open Browser  ${SITE_URL}/account/auth  ${BROWSER}
-	Log In As     login=coder  password=test
-	Go To         ${SITE_URL}/series/5
+	Open Browser     ${SITE_URL}/account/auth  ${BROWSER}
+	Set Window Size  width=1024  height=768
+	Log In As        login=coder  password=test
+	Go To            ${SITE_URL}/series/5

--- a/src/test/robotframework/series/add-comment/validation.robot
+++ b/src/test/robotframework/series/add-comment/validation.robot
@@ -5,7 +5,7 @@ Resource        ../../auth.steps.robot
 Resource        ../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  add-comment  validation  htmx
+Force Tags      series  add-comment  validation
 
 *** Test Cases ***
 Add comment with empty required field

--- a/src/test/robotframework/series/add-image/logic.robot
+++ b/src/test/robotframework/series/add-image/logic.robot
@@ -5,7 +5,7 @@ Resource         ../../auth.steps.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Before Test
-Force Tags       series  add-image  logic  htmx
+Force Tags       series  add-image  logic
 
 *** Test Cases ***
 Add additional image by uploading a file

--- a/src/test/robotframework/series/add-image/validation.robot
+++ b/src/test/robotframework/series/add-image/validation.robot
@@ -4,7 +4,7 @@ Library          SeleniumLibrary
 Resource         ../../auth.steps.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
-Force Tags       series  add-image  validation  htmx
+Force Tags       series  add-image  validation
 
 *** Test Cases ***
 Add image with empty required fields

--- a/src/test/robotframework/series/add-numbers/logic.robot
+++ b/src/test/robotframework/series/add-numbers/logic.robot
@@ -5,7 +5,7 @@ Library         String
 Resource        ../../auth.steps.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  add-numbers  logic  htmx
+Force Tags      series  add-numbers  logic
 
 *** Test Cases ***
 Add catalog numbers

--- a/src/test/robotframework/series/add-price/logic.robot
+++ b/src/test/robotframework/series/add-price/logic.robot
@@ -9,7 +9,6 @@ Force Tags      series  add-price  logic
 
 *** Test Cases ***
 Add a price by a catalog
-	[Tags]      unstable
 	[Template]  Add a price
 	michel      10  EUR
 	scott       20  USD

--- a/src/test/robotframework/series/add-price/logic.robot
+++ b/src/test/robotframework/series/add-price/logic.robot
@@ -5,7 +5,7 @@ Library         String
 Resource        ../../auth.steps.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  add-price  logic  htmx
+Force Tags      series  add-price  logic
 
 *** Test Cases ***
 Add a price by a catalog

--- a/src/test/robotframework/series/add-year/logic.robot
+++ b/src/test/robotframework/series/add-year/logic.robot
@@ -4,7 +4,7 @@ Library         SeleniumLibrary
 Resource        ../../auth.steps.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  add-year  logic  htmx
+Force Tags      series  add-year  logic
 
 *** Test Cases ***
 Add a release year

--- a/src/test/robotframework/series/creation/logic-admin.robot
+++ b/src/test/robotframework/series/creation/logic-admin.robot
@@ -6,7 +6,7 @@ Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Before Test
-Force Tags       series  logic  htmx
+Force Tags       series  logic
 
 *** Test Cases ***
 Create series by filling only required fields and providing an image
@@ -40,6 +40,7 @@ Create series by filling all fields
 	Select From List By Value  id:month  5
 	Select From List By Value  id:year   1999
 	Click Element              id:add-catalog-numbers-link
+	Scroll Element Into View   id:michelNumbers
 	Input Text                 id:michelNumbers    101, 102, 103
 	Input Text                 id:michelPrice      10.5
 	Input Text                 id:scottNumbers     110, 111, 112
@@ -69,8 +70,9 @@ Create series by filling all fields
 
 *** Keywords ***
 Before Test Suite
-	Open Browser  ${SITE_URL}/account/auth  ${BROWSER}
-	Log In As     login=admin  password=test
+	Open Browser     ${SITE_URL}/account/auth  ${BROWSER}
+	Set Window Size  width=1024  height=768
+	Log In As        login=admin  password=test
 
 Before Test
 	Go To  ${SITE_URL}/series/add

--- a/src/test/robotframework/series/creation/logic-user.robot
+++ b/src/test/robotframework/series/creation/logic-user.robot
@@ -6,7 +6,7 @@ Resource         ../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Before Test
-Force Tags       series  logic  htmx
+Force Tags       series  logic
 
 *** Test Cases ***
 Create series by filling only required fields
@@ -30,6 +30,7 @@ Create series by filling all fields
 	Select From List By Value  id:month  9
 	Select From List By Value  id:year   1999
 	Click Element              id:add-catalog-numbers-link
+	Scroll Element Into View   id:michelNumbers
 	Input Text                 id:michelNumbers    1, 2, 3
 	Input Text                 id:michelPrice      10.5
 	Input Text                 id:scottNumbers     10, 11, 12
@@ -59,8 +60,9 @@ Create series by filling all fields
 
 *** Keywords ***
 Before Test Suite
-	Open Browser  ${SITE_URL}/account/auth  ${BROWSER}
-	Log In As     login=coder  password=test
+	Open Browser     ${SITE_URL}/account/auth  ${BROWSER}
+	Set Window Size  width=1024  height=768
+	Log In As        login=coder  password=test
 
 Before Test
 	Go To  ${SITE_URL}/series/add

--- a/src/test/robotframework/series/creation/misc.robot
+++ b/src/test/robotframework/series/creation/misc.robot
@@ -47,12 +47,12 @@ Catalog numbers should be stripped from any spaces
 	Textfield Value Should Be      id:zagorskiNumbers  11,12
 
 Catalog numbers should ignore duplicate values
-	[Tags]                     htmx
 	Go To                      ${SITE_URL}/series/add
 	Select From List By Label  id:category  Sport
 	Input Text                 id:quantity  2
 	Choose File                id:image  ${MAIN_RESOURCE_DIR}${/}test.png
 	Click Element              id:add-catalog-numbers-link
+	Scroll Element Into View   id:michelNumbers
 	Input Text                 id:michelNumbers    104,105,104
 	Input Text                 id:scottNumbers     114,115,114
 	Input Text                 id:yvertNumbers     124,125,124
@@ -68,12 +68,12 @@ Catalog numbers should ignore duplicate values
 	Element Text Should Be     id:zagorski_catalog_info  \#154, 155
 
 Catalog numbers should accept existing numbers
-	[Tags]                     htmx
 	Go To                      ${SITE_URL}/series/add
 	Select From List By Label  id:category  Sport
 	Input Text                 id:quantity  2
 	Choose File                id:image  ${MAIN_RESOURCE_DIR}${/}test.png
 	Click Element              id:add-catalog-numbers-link
+	Scroll Element Into View   id:michelNumbers
 	Input Text                 id:michelNumbers    99
 	Input Text                 id:scottNumbers     99
 	Input Text                 id:yvertNumbers     99
@@ -90,9 +90,11 @@ Catalog numbers should accept existing numbers
 
 *** Keywords ***
 Before Test Suite
-	Open Browser  ${SITE_URL}/account/auth  ${BROWSER}
-	Log In As     login=coder  password=test
-	Go To         ${SITE_URL}/series/add
+	Open Browser     ${SITE_URL}/account/auth  ${BROWSER}
+	# @todo #1749 Adjust browser window size globally
+	Set Window Size  width=1024  height=768
+	Log In As        login=coder  password=test
+	Go To            ${SITE_URL}/series/add
 
 Valid Catalog Numbers Should Be Accepted
 	[Arguments]                      ${catalogNumbers}

--- a/src/test/robotframework/series/creation/validation-user.robot
+++ b/src/test/robotframework/series/creation/validation-user.robot
@@ -76,34 +76,35 @@ Before Test Suite
 	Go To            ${SITE_URL}/series/add
 
 Invalid Catalog Numbers Should Be Rejected
-	[Arguments]                    ${catalogNumbers}
+	[Arguments]                       ${catalogNumbers}
 	# open page each time to be sure that we're starting from the clean state.
 	# Otherwise it's possible that there errors from the previous test and when
 	# we'll click on link for adding catalog numbers then fields become
 	# invisible (because link is toggling the visibility and when there are
 	# errors, fields are visible from the begining).
-	Go To                          ${SITE_URL}/series/add
-	Disable Client Validation      add-series-form
-	Click Element                  id:add-catalog-numbers-link
+	Go To                             ${SITE_URL}/series/add
+	Disable Client Validation         add-series-form
+	Click Element                     id:add-catalog-numbers-link
 	# we should wait until all 4 fields with class js-catalogs-info will be
 	# visible but for simplicity we just check that the last field is visible
-	Wait Until Element Is Visible  id:gibbonsNumbers
-	Input Text                     id:michelNumbers    ${catalogNumbers}
-	Input Text                     id:scottNumbers     ${catalogNumbers}
-	Input Text                     id:yvertNumbers     ${catalogNumbers}
-	Input Text                     id:gibbonsNumbers   ${catalogNumbers}
-	Input Text                     id:solovyovNumbers  ${catalogNumbers}
-	Input Text                     id:zagorskiNumbers  ${catalogNumbers}
-	Submit Form                    id:add-series-form
-	${alnumMessage}                Catenate  SEPARATOR=${SPACE}
-	...                            Value must be a list of numbers separated by comma.
-	...                            Any number may end with a latin letter in lower case
-	Element Text Should Be         id:michelNumbers.errors    ${alnumMessage}
-	Element Text Should Be         id:scottNumbers.errors     ${alnumMessage}
-	Element Text Should Be         id:yvertNumbers.errors     ${alnumMessage}
-	Element Text Should Be         id:gibbonsNumbers.errors   Value must be a list of numbers separated by comma
-	Element Text Should Be         id:solovyovNumbers.errors  Value must be a list of numbers separated by comma
-	Element Text Should Be         id:zagorskiNumbers.errors  Value must be a list of numbers separated by comma
+	Wait Until Element Is Visible     id:gibbonsNumbers
+	Input Text                        id:michelNumbers    ${catalogNumbers}
+	Input Text                        id:scottNumbers     ${catalogNumbers}
+	Input Text                        id:yvertNumbers     ${catalogNumbers}
+	Input Text                        id:gibbonsNumbers   ${catalogNumbers}
+	Input Text                        id:solovyovNumbers  ${catalogNumbers}
+	Input Text                        id:zagorskiNumbers  ${catalogNumbers}
+	Submit Form                       id:add-series-form
+	${alnumMessage}                   Catenate  SEPARATOR=${SPACE}
+	...                               Value must be a list of numbers separated by comma.
+	...                               Any number may end with a latin letter in lower case
+	Wait Until Page Contains Element  id:michelNumbers.errors
+	Element Text Should Be            id:michelNumbers.errors    ${alnumMessage}
+	Element Text Should Be            id:scottNumbers.errors     ${alnumMessage}
+	Element Text Should Be            id:yvertNumbers.errors     ${alnumMessage}
+	Element Text Should Be            id:gibbonsNumbers.errors   Value must be a list of numbers separated by comma
+	Element Text Should Be            id:solovyovNumbers.errors  Value must be a list of numbers separated by comma
+	Element Text Should Be            id:zagorskiNumbers.errors  Value must be a list of numbers separated by comma
 
 Invalid Catalog Price Should Be Rejected
 	[Arguments]                    ${catalogPrice}

--- a/src/test/robotframework/series/creation/validation-user.robot
+++ b/src/test/robotframework/series/creation/validation-user.robot
@@ -28,9 +28,10 @@ Create series with too small quantity
 	Element Text Should Be  id:quantity.errors  Value must be greater than or equal to 1
 
 Create series with too large quantity
-	Input Text              id:quantity  156
-	Submit Form             id:add-series-form
-	Element Text Should Be  id:quantity.errors  Value must be less than or equal to 150
+	Input Text                        id:quantity  156
+	Submit Form                       id:add-series-form
+	Wait Until Page Contains Element  id:quantity.errors
+	Element Text Should Be            id:quantity.errors  Value must be less than or equal to 150
 
 Create series with an empty image
 	Choose File             id:image  ${TEST_RESOURCE_DIR}${/}empty.jpg

--- a/src/test/robotframework/series/creation/validation-user.robot
+++ b/src/test/robotframework/series/creation/validation-user.robot
@@ -70,9 +70,10 @@ Catalog price should reject invalid values
 
 *** Keywords ***
 Before Test Suite
-	Open Browser  ${SITE_URL}/account/auth  ${BROWSER}
-	Log In As     login=coder  password=test
-	Go To         ${SITE_URL}/series/add
+	Open Browser     ${SITE_URL}/account/auth  ${BROWSER}
+	Set Window Size  width=1024  height=768
+	Log In As        login=coder  password=test
+	Go To            ${SITE_URL}/series/add
 
 Invalid Catalog Numbers Should Be Rejected
 	[Arguments]                    ${catalogNumbers}

--- a/src/test/robotframework/series/import/import-validation.robot
+++ b/src/test/robotframework/series/import/import-validation.robot
@@ -4,7 +4,7 @@ Library         SeleniumLibrary
 Resource        ../../auth.steps.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  import-series  validation  htmx
+Force Tags      series  import-series  validation
 
 *** Test Cases ***
 Price and currency should be optional when seller information isn't provided

--- a/src/test/robotframework/series/import/request-logic.robot
+++ b/src/test/robotframework/series/import/request-logic.robot
@@ -160,4 +160,4 @@ Before Test Suite
 
 Before Test
 	Go To            ${SITE_URL}/series/import/request
-	Set Window Size  width=1024  height=768
+	Set Window Size  width=1366  height=768

--- a/src/test/robotframework/series/import/request-logic.robot
+++ b/src/test/robotframework/series/import/request-logic.robot
@@ -12,7 +12,6 @@ Force Tags       series  import-series  logic
 *** Test Cases ***
 Import series from an external site (in English, use category, country and date locators)
 	[Documentation]                  Verify import from a page in English and with different locators
-	[Tags]                           htmx
 	${importUrl}=                    Set Variable  http://127.0.0.1:8080/series/2?lang=en
 	Input Text                       id:url  ${importUrl}
 	Submit Form                      id:import-series-form
@@ -70,7 +69,6 @@ Import series from an external site (in Russian, use description locator)
 
 Import series from external site with catalog numbers (use description locator)
 	[Documentation]             Verify import of catalog numbers by extracting them from a description
-	[Tags]                      htmx
 	Input Text                  id:url  ${MOCK_SERVER}/series/import/request-logic/catalog-numbers-in-description.html
 	Submit Form                 id:import-series-form
 	Textfield Value Should Be   id:michel-numbers   2242-2246
@@ -91,7 +89,6 @@ Import series when a page in a non-utf-8 charset
 
 Import series and series sale with existing seller from an external site
 	[Documentation]             Verify import series and sale (with existing seller)
-	[Tags]                      htmx
 	Input Text                  id:url  ${MOCK_SERVER}/series/import/request-logic/existing-seller.html
 	Submit Form                 id:import-series-form
 	${requestLocation}=         Get Location
@@ -99,7 +96,7 @@ Import series and series sale with existing seller from an external site
 	List Selection Should Be    id:seller        Eicca Toppinen
 	Textfield Value Should Be   id:price         111
 	List Selection Should Be    id:currency      RUB
-	Textfield Value Should Be   id:alt-price     1.5
+	Textfield Value Should Be   id:alt-price     1.50
 	List Selection Should Be    id:alt-currency  EUR
 	Submit Form                 id:create-series-form
 	# after importing a series, sale info should be shown at the info page
@@ -117,7 +114,6 @@ Import series and series sale with existing seller from an external site
 
 Import series and series sale with a new seller from an external site
 	[Documentation]             Verify import series and sale (with a new seller)
-	[Tags]                      htmx
 	Input Text                  id:url  ${MOCK_SERVER}/series/import/request-logic/new-seller.html
 	Submit Form                 id:import-series-form
 	${requestLocation}=         Get Location
@@ -163,4 +159,5 @@ Before Test Suite
 	Log In As     login=admin  password=test
 
 Before Test
-	Go To  ${SITE_URL}/series/import/request
+	Go To            ${SITE_URL}/series/import/request
+	Set Window Size  width=1024  height=768

--- a/src/test/robotframework/series/sales/creation/logic.robot
+++ b/src/test/robotframework/series/sales/creation/logic.robot
@@ -5,7 +5,7 @@ Resource         ../../../auth.steps.robot
 Resource         ../../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
-Force Tags       series  sales  logic  htmx
+Force Tags       series  sales  logic
 
 *** Test Cases ***
 Add a sale with only required fields

--- a/src/test/robotframework/series/sales/creation/misc.robot
+++ b/src/test/robotframework/series/sales/creation/misc.robot
@@ -5,7 +5,7 @@ Resource         ../../../auth.steps.robot
 Resource         ../../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
-Force Tags       series  sales  misc  htmx
+Force Tags       series  sales  misc
 
 *** Test Cases ***
 Url should be stripped from leading and trailing spaces

--- a/src/test/robotframework/series/sales/creation/validation.robot
+++ b/src/test/robotframework/series/sales/creation/validation.robot
@@ -6,7 +6,7 @@ Resource         ../../../selenium.utils.robot
 Suite Setup      Before Test Suite
 Suite Teardown   Close Browser
 Test Setup       Disable Client Validation  add-series-sales-form
-Force Tags       series  sales  validation  htmx
+Force Tags       series  sales  validation
 
 *** Test Cases ***
 Create series with empty required fields

--- a/src/test/robotframework/series/sales/import/logic.robot
+++ b/src/test/robotframework/series/sales/import/logic.robot
@@ -5,7 +5,7 @@ Resource        ../../../auth.steps.robot
 Resource        ../../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  sales  import-sales  logic  htmx
+Force Tags      series  sales  import-sales  logic
 
 *** Test Cases ***
 Import a series sale with an existing seller

--- a/src/test/robotframework/series/sales/import/validation.robot
+++ b/src/test/robotframework/series/sales/import/validation.robot
@@ -5,7 +5,7 @@ Resource        ../../../auth.steps.robot
 Resource        ../../../selenium.utils.robot
 Suite Setup     Before Test Suite
 Suite Teardown  Close Browser
-Force Tags      series  sales  import-sales  validation  htmx
+Force Tags      series  sales  import-sales  validation
 
 *** Test Cases ***
 Import a series sale with empty required field

--- a/src/test/robotframework/site/csp/report-logic.robot
+++ b/src/test/robotframework/site/csp/report-logic.robot
@@ -1,10 +1,9 @@
 *** Settings ***
 Documentation  Verify CSP report submission scenario
-Library        HttpRequestLibrary
+Library        RequestsLibrary
 Force Tags     site  csp  logic
 
 *** Test Cases ***
 CSP report should be accepted
-    Create Session           server  ${SITE_URL}
-    Post Request             server  /site/csp/reports  data="{}"
-    Response Code Should Be  server  204
+    Create Session   server  ${SITE_URL}
+    POST On Session  server  /site/csp/reports  data="{}"  expected_status=204


### PR DESCRIPTION
Fixes #1749

TODO:
- [x] Step 1: run tests on CI
   - [x] fix `Parent suite setup failed: TypeError: WebDriver.__init__() got an unexpected keyword argument 'service_log_path'`
        - [x] install chromedriver (with mise)
           - [x] show chromedriver version 
   - [x] use python from `mise.toml`
      - [ ] fix `mise WARN  no precompiled python found for 3.6.15, force mise to use a precompiled version with "mise settings set python.compile false"`
- [x] Step 2: make them pass
   - [x] fix `Importing test library 'HttpRequestLibrary' failed: ModuleNotFoundError: No module named 'HttpRequestLibrary'`
   - fix critical tests: 5 failed:
      - [x] fix `Account.Authentication.Logic.Successful authentication: Page should have contained button 'value:Sign out' but did not.`
      - [x] fix `Site.Csp.Report-Logic.CSP report should be accepted: No keyword with name 'Create Session' found.`
         - [x] fix `Site.Csp.Report-Logic.CSP report should be accepted: No keyword with name 'Response Code Should Be' found.`
      - [x] fix `Country.Creation.Logic.Create country with name in English (fill only mandatory fields): No keyword with name 'Xpath Should Match X Times' found.`
      - [x] fix `Series.Search.Logic-User.Search series by non-existing catalog number in a collection: TypeError: sequence item 0: expected str instance, int found`
      - [x] fix `Series.Search.Logic-Anonymous.Search series by non-existing catalog number: TypeError: sequence item 0: expected str instance, int found`
- [x] Step 3: fix htmx-related tests (14 failed) and stop ignoring them:
   - [x] fix `Series.Sales.Creation.Logic.Add a sale with all fields: Keyword 'SeleniumLibrary.Get Element Attribute' expected 2 arguments, got 1`
   - [x] fix `Series.Creation.Misc.Catalog numbers should ignore duplicate values: ElementNotInteractableException: Message: element not interactable`
   - [x] fix `Series.Creation.Misc.Catalog numbers should accept existing numbers: ElementNotInteractableException: Message: element not interactable`
   - [x] fix `Series.Add-Numbers.Logic.Add catalog numbers: Several failures occurred: 1) NoSuchElementException: Message: Cannot locate option with value: michel`
   - [x] fix `Series.Add-Comment.Validation.Add comment with empty required field
Element 'id:new-comment.errors' did not appear in 5 seconds` (#1842)
      - [x] fix `Series.Add-Comment.Validation.Add comment with empty required field: The text of element 'id:new-comment.errors' should have been 'must not be empty' but it was 'must not be blank'`
   - [x] fix `Series.Add-Comment.Validation.Add a blank comment: Element with locator 'id:new-comment' not found` (#1842)
      - [x] fix `Series.Add-Comment.Validation.Add a blank comment: The text of element 'id:new-comment.errors' should have been 'must not be empty' but it was 'must not be blank'`
   - [x] fix `Series.Add-Comment.Validation.Add too long comment: Element with locator 'id:new-comment' not found` (#1842)
   - [x] fix `Series.Import.Request-Logic.Import series from external site with catalog numbers (use description locator):ElementClickInterceptedException: Message: element click intercepted: Element <a id="import-request-link" href="/series/import/request/8">...</a> is not clickable at point (587, 183)`
   - [x] fix `Series.Import.Request-Logic.Import series and series sale with existing seller from an external site: Value of text field 'id:alt-price' should have been '1.5' but was '1.50'`
      - [x] fix `Series.Import.Request-Logic.Import series and series sale with existing seller from an external site
Keyword 'SeleniumLibrary.Get Element Attribute' expected 2 arguments, got 1`
   - [x] fix `Series.Import.Request-Logic.Import series and series sale with a new seller from an external site: Keyword 'SeleniumLibrary.Get Element Attribute' expected 2 arguments, got 1`
   - [x] fix `Collection.Remove-Series.Logic.Remove the first instance of a series from user's collection: No keyword with name 'Xpath Should Match X Times' found`
   - [x] fix `Collection.Remove-Series.Logic.Remove the last instance of a series from user's collection: No keyword with name 'Xpath Should Match X Times' found`
   - [x] fix `Collection.Estimation.Logic.Series with its price should be taken into account: Keyword 'SeleniumLibrary.Table Cell Should Contain' expected 4 to 5 arguments, got 3`
      - [x] fix `Collection.Estimation.Logic.Series with its price should be taken into account: Table 'collection-estimation' footer did not contain text '100.00 RUB'`
   - [x] fix `Collection.Estimation.Logic.Series without price should be shown but not taken into account: Keyword 'SeleniumLibrary.Table Cell Should Contain' expected 4 to 5 arguments, got 3`
      - [x] fix `Collection.Estimation.Logic.Series without price should be shown but not taken into account
Table 'collection-estimation' footer did not contain text '100.00 RUB'`
   - [x] fix `Collection.Add-Series.Logic.Add the same series to user's collection again (incomplete series): No keyword with name 'Xpath Should Match X Times' found`
   - [x] fix `Series.Creation.Logic-Admin.Create series by filling all fields: ElementNotInteractableException: Message: element not interactable`
   - [ ] fix `Country.Creation.Logic.Create country with name in English (fill only mandatory fields): Element with locator 'id:country-selectized' not found`
   - [x] fix `Series.Creation.Logic-User.Create series by filling all fields: ElementNotInteractableException: Message: element not interactable`
   - [x] fix `Series.Add-Comment.Validation.Add a blank comment: StaleElementReferenceException: Message: stale element reference: stale element not found in the current frame`
- [x] Step 4: revise tests tagged by `unstable`
   - [x] fix `Account.Registration.Logic.After account creation an e-mail with activation link should be send: Resolving variable '${response.json['requests']}' failed: TypeError: 'method' object is not subscriptable`
      - [ ] how to extract `response.json()` into variable?
      - [x] fix `Account.Registration.Logic.After account creation an e-mail with activation link should be send
Length of '[]' should be 1 but is 0` (#1131)
         - [x] backport to master
   - [x] fix `Series.Add-Price.Logic.Add a price by a catalog: Several failures occurred: 1) NoSuchElementException: Message: Cannot locate option with value: michel`
- [x] Step 5: make tests pass locally
   - [x] fix `Series.Creation.Validation-User.Create series with day of month but without month: ElementNotInteractableException: Message: element not interactable: Element is not currently visible and may not be manipulated`
   - [x] fix `Collection.Add-Series.Logic.Add a series to user's collection (all stamps): The text of element 'id:number-of-stamps-block' should have been 'I have out of 2 stamps' but it was 'I have\nout of 2 stamps'.`
   - [x] fix `Collection.Add-Series.Logic.Add the same series to user's collection again (incomplete series): The text of element 'id:series-status-msg' should have been 'You already have this series. Add another one instance:' but it was 'You don't have this series. Add one instance:'.`
   - [ ] fix `Series.Search.Validation.Search the series with empty required field: Element with locator 'id:catalogNumber.errors' not found`
   - [x] fix `Series.Creation.Validation-User.Create series with too large quantity: Element with locator 'id:quantity.errors' not found`
   - [x] fix `Series.Creation.Validation-User.Catalog numbers should reject invalid values: Element with locator 'id:michelNumbers.errors' not found`
- [ ] Step 6: fix warnings
   - [ ] fix `[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use 'POST On Session' instead.`
   - [x] fix `Keyword 'Save Screenshot and Log Source' could not be run on failure: No keyword with name 'Save Screenshot and Log Source' found`
   - [x] fix CSP warnings
     - [x] fix `{ "violated-directive": "style-src-elem", "effective-directive": "style-src-elem", "blocked-uri": "inline", "script-sample": ".htmx-indicator{opacity:0;visibility: hi" }` (#1844)
     - [x] fix `{"document-uri" : "http://127.0.0.1:8080/collection/paid/estimation", "violated-directive": "style-src-attr", "effective-directive": "style-src-attr", "blocked-uri":"inline", "script-sample": "font-weight: bold" }`
- [x] specify locator explicitly for `Table Cell Should Contain` and `Table Footer Should Contain`
- [ ] unbreak after Chrome update: `Parent suite setup failed: SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 147 Current browser version is 146.0.7680.177 with binary path /opt/google/chrome/chrome`
- [x] deal with `robot --version` workaround
   - [x] reproduce on fresh version
   - [x] submit an issue or update comment
- [x] deal with `Table Footer Should Contain` workaround
   - [x] reproduce on fresh version; I checked the code
   - [x] submit an issue or add a comment (issue was already submitted: https://github.com/robotframework/SeleniumLibrary/issues/1436)
- [ ] configure dependabot to watch for `requirements.txt`
- [ ] deal with caching
   - [ ] cache python dependencies
   - [ ] cache chrome/chromedriver (see also: `browser-actions/setup-chrome#640`)
 - [x] speed up CI for development
    - [x] disable unrelated workflows
       - [x] revert
    - [x] disable jdk 11/17
       - [x] revert
- [ ] Prepare for merge
   - [x] update mysql/postgresql workflows
   - [x] group commits
   - [ ] remove `gh1749_python_robotframework_original` branch
   - [ ] add `Fix`/`Part of` comments
   - [x] close test flakes
- [ ] fix action warnings
   - [ ] `Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: jdx/mise-action@v3.5.1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see:ttps://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`
   - [ ] setup-java: `(node:2341) [DEP0040] DeprecationWarning: The 'punycode' module is deprecated. Please use a userland alternative instead. (Use 'node --trace-deprecation ...' to show where the warning was created)`
   - [ ] upload-artifact: `Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`